### PR TITLE
issue4 SPDX > Per File Info 내 오픈소스 정보 포함

### DIFF
--- a/onot/parsing/excel.py
+++ b/onot/parsing/excel.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
-import os.path
-import re
 
 # SPDX-FileCopyrightText: Copyright 2022 SK TELECOM CO., LTD. <haksung@sk.com>
+# SPDX-FileCopyrightText: Copyright (c) 2022 Kakao Corp. https://www.kakaocorp.com
+#
 # SPDX-License-Identifier: Apache-2.0
+
+import os.path
+import re
 import openpyxl
 import pandas as pd
 from onot.parsing import spdx_license

--- a/onot/parsing/excel.py
+++ b/onot/parsing/excel.py
@@ -139,8 +139,8 @@ class Parser():
             package = {
                 "name": package_info[0],
                 "versionInfo": str(package_info[1]),
-                "licenseConcluded": str(package_info[2]).replace("(", "").replace(")", ""),
-                "licenseDeclared": str(package_info[3]).replace("(", "").replace(")", ""),
+                "licenseConcluded": str(package_info[2]).replace("(", "").replace(")", "").split("OR")[0].strip(),
+                "licenseDeclared": str(package_info[3]).replace("(", "").replace(")", "").split("OR")[0].strip(),
                 "copyrightText": package_info[4],
                 "downloadLocation": package_info[5].replace("\"", ""),
             }
@@ -197,8 +197,8 @@ class Parser():
             package = {
                 "name": package_name,
                 "versionInfo": str(package_version),
-                "licenseConcluded": str(per_file_info[1]).replace("(", "").replace(")", ""),
-                "licenseDeclared": str(per_file_info[2]).replace("(", "").replace(")", ""),
+                "licenseConcluded": str(per_file_info[1]).replace("(", "").replace(")", "").split("OR")[0].strip(),
+                "licenseDeclared": str(per_file_info[2]).replace("(", "").replace(")", "").split("OR")[0].strip(),
                 "copyrightText": per_file_info[3],
                 "downloadLocation": str(per_file_info[4]).replace("\"", "")
             }
@@ -252,7 +252,6 @@ class Parser():
             license_name = package["licenseConcluded"]
             if license_name is None:
                 license_name = package["licenseDeclared"]
-            license_name = str(license_name).split("OR")[0].strip()
 
             # check whether the licenseId is existed in the spdx license list
             details_url = sl.get_spdx_license_detailsUrl(license_name)

--- a/onot/parsing/excel.py
+++ b/onot/parsing/excel.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import os.path
+import re
 
 # SPDX-FileCopyrightText: Copyright 2022 SK TELECOM CO., LTD. <haksung@sk.com>
 # SPDX-License-Identifier: Apache-2.0
@@ -10,6 +12,7 @@ from onot.parsing import spdx_license
 SHEET_DOCUMENT_INFO = "Document Info"
 SHEET_PACKAGE_INFO = "Package Info"
 SHEET_EXTRACTED_LICENSE_INFO = "Extracted License Info"
+SHEET_PER_FILE_INFO = "Per File Info"
 
 # columns
 COLUMN_DOCUMENT_NAME = "Document Name"
@@ -23,6 +26,10 @@ COLUMN_PACKAGE_COPYRIGHT_TEXT = "Package Copyright Text"
 COLUMN_IDENTIFIER = "Identifier"
 COLUMN_EXTRACTED_TEXT = "Extracted Text"
 COLUMN_LICENSE_NAME = "License Name"
+COLUMN_FILE_NAME = "File Name"
+COLUMN_LICENSE_INFO_IN_FILE = "License Info in File"
+COLUMN_FILE_COPYRIGHT_TEXT = "File Copyright Text"
+COLUMN_ARTIFACT_OF_HOMEPAGE = "Artifact of Homepage"
 
 class Parser():
 
@@ -49,6 +56,7 @@ class Parser():
             SHEET_DOCUMENT_INFO,
             SHEET_PACKAGE_INFO,
             # SHEET_EXTRACTED_LICENSE_INFO,
+            SHEET_PER_FILE_INFO
         ]
         for sheet in required_sheets:
             if sheet not in ws_names:
@@ -84,6 +92,13 @@ class Parser():
                     raise ValueError("email info is not existed.") 
         if "creationInfo" not in self.doc:
             raise ValueError("Organization info is not existed in the " + SHEET_DOCUMENT_INFO) 
+
+    def append_package(self, package_to_be_appended):
+        # Check if there are duplicate packages already appended
+        if any(package["name"] == package_to_be_appended["name"] and package["versionInfo"] == package_to_be_appended["versionInfo"] for package in self.packages):
+            return
+        self.packages.append(package_to_be_appended)
+
 
     def package_info(self):
         sheet = self.wb.get_sheet_by_name(SHEET_PACKAGE_INFO)
@@ -124,13 +139,70 @@ class Parser():
             package = {
                 "name": package_info[0],
                 "versionInfo": str(package_info[1]),
-                "licenseConcluded": package_info[2],
-                "licenseDeclared": package_info[3],
+                "licenseConcluded": str(package_info[2]).replace("(", "").replace(")", ""),
+                "licenseDeclared": str(package_info[3]).replace("(", "").replace(")", ""),
                 "copyrightText": package_info[4],
-                "downloadLocation": package_info[5],
+                "downloadLocation": package_info[5].replace("\"", ""),
             }
-            self.packages.append(package)
+            self.append_package(package)
         self.doc["packages"] = self.packages
+
+    def extract_package_name_and_package_version(self, filename):
+        def remove_meaningless_word(_filename):
+            _filename = _filename.replace("-sources", "")
+            _filename = _filename.replace("-RELEASE", "")
+            _filename = _filename.replace("-SNAPSHOT", "")
+            return _filename
+
+        filename = os.path.splitext(os.path.basename(filename))[0]
+        filename = remove_meaningless_word(filename)
+        version = re.search(r"-\d", filename)
+
+        if version:
+            return filename[:version.start()], filename[version.start()+1:]
+        else:
+            return filename, ""
+
+    def per_file_info(self):
+        sheet = self.wb.get_sheet_by_name(SHEET_PER_FILE_INFO)
+        df = pd.DataFrame(sheet.values)
+        df.columns = df.iloc[0, :]
+        df = df.iloc[1:, :]
+
+        if COLUMN_FILE_NAME not in df.columns:
+            raise ValueError("required column is not existed: " + COLUMN_FILE_NAME)
+        if COLUMN_LICENSE_CONCLUDED not in df.columns:
+            raise ValueError("required column is not existed: " + COLUMN_LICENSE_CONCLUDED)
+        if COLUMN_LICENSE_INFO_IN_FILE not in df.columns:
+            raise ValueError("required column is not existed: " + COLUMN_LICENSE_INFO_IN_FILE)
+        if COLUMN_FILE_COPYRIGHT_TEXT not in df.columns:
+            raise ValueError("required column is not existed: " + COLUMN_FILE_COPYRIGHT_TEXT)
+        if COLUMN_ARTIFACT_OF_HOMEPAGE not in df.columns:
+            raise ValueError("required column is not existed: " + COLUMN_ARTIFACT_OF_HOMEPAGE)
+
+        per_file_info_list = df.loc[:,
+            [
+                COLUMN_FILE_NAME,
+                COLUMN_LICENSE_CONCLUDED,
+                COLUMN_LICENSE_INFO_IN_FILE,
+                COLUMN_FILE_COPYRIGHT_TEXT,
+                COLUMN_ARTIFACT_OF_HOMEPAGE
+            ]].values.tolist()
+        for per_file_info in per_file_info_list:
+            for index, value in enumerate(per_file_info):
+                if value is None:
+                    per_file_info[index] = ''
+
+            package_name, package_version = self.extract_package_name_and_package_version(per_file_info[0])
+            package = {
+                "name": package_name,
+                "versionInfo": str(package_version),
+                "licenseConcluded": str(per_file_info[1]).replace("(", "").replace(")", ""),
+                "licenseDeclared": str(per_file_info[2]).replace("(", "").replace(")", ""),
+                "copyrightText": per_file_info[3],
+                "downloadLocation": str(per_file_info[4]).replace("\"", "")
+            }
+            self.append_package(package)
 
     def extracted_license_info(self):
         sheet = self.wb.get_sheet_by_name(SHEET_EXTRACTED_LICENSE_INFO)
@@ -155,6 +227,10 @@ class Parser():
                 ]].values.tolist()
         self.extracted_licenses = []
         for extracted_license_info in extracted_license_list:
+            for index, value in enumerate(extracted_license_info):
+                if value is None:
+                    extracted_license_info[index] = ''
+
             extracted_license = {
                 "identifier": extracted_license_info[0],
                 "extractedText": extracted_license_info[1],
@@ -176,7 +252,8 @@ class Parser():
             license_name = package["licenseConcluded"]
             if license_name is None:
                 license_name = package["licenseDeclared"]
-            
+            license_name = str(license_name).split("OR")[0].strip()
+
             # check whether the licenseId is existed in the spdx license list
             details_url = sl.get_spdx_license_detailsUrl(license_name)
             print("debug: " + str(details_url))
@@ -236,6 +313,9 @@ class Parser():
 
         # Package info
         self.package_info()
+
+        # Per File Info
+        self.per_file_info()
 
         # License info
         self.license_info()


### PR DESCRIPTION
안녕하세요~ 카카오 로저스입니다.
고지문 오픈소스에 기여할 수 있게 되어 기쁩니다 :)

[4번째 이슈](https://github.com/sktelecom/onot/issues/4) 를 해결한 PR입니다.
1. SPDX 파일의 Per File Info 내 오픈소스 정보도 포함시키도록 파싱 로직을 추가하였습니다.
   * 패키지 이름과 버전은 File Name 컬럼에서 추출했습니다.
   * 라이선스 정보는 License Conculuded 와 License Info in File에서 추출했습니다.
   * CopyrightText 정보는 File Copyright Text 에서 추출했습니다.
   * downloadLocation 정보는 Artifact of Homepage 에서 추출했습니다.
2. 중복 컴포넌트가 아닌 경우에만 패키지 정보를 추가하도록 했습니다.
3. Per File Info 내용을 포함시키면서 추가로 필요한 파싱들을 추가했습니다.
   * 라이선스 정보가 괄호안에 있는 경우
   * 다운로드 정보가 큰 따옴표 안에 있는 경우
4. sample 파일에 있는 듀얼 라이선스는 임시로 첫번째 라이선스만 뜨도록 처리했습니다. 이후 https://github.com/sktelecom/onot/issues/5 이슈를 진행하면서 듀얼 라이선스 처리하려고 합니다.
   * sample 파일의 Per File Info에서 /package/foo.c의 라이선스가 (LGPL-2.0-or-later OR LicenseRef-2) 라고 표기되어있는데 LGPL-2.0-or-later 만 표기되도록 했습니다. 

터미널 환경에서 다음 명령어로 프로그램 실행하여 확인했습니다.
`python3 -m onot --input sample/SPDXRdfExample-v2.1.xlsx --output_format html`

제가 이슈를 잘못 파악한 부분이 있거나 코드상 리팩터링이 필요한 부분이 있다면 코멘트 부탁드립니다~
감사합니다 :)