### PR TITLE
Issue5 Dual License 표기 처리

### DIFF
--- a/onot/generating/html.py
+++ b/onot/generating/html.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: Copyright 2022 SK TELECOM CO., LTD. <haksung@sk.com>
+# SPDX-FileCopyrightText: Copyright (c) 2022 Kakao Corp. https://www.kakaocorp.com
+#
 # SPDX-License-Identifier: Apache-2.0
+
 import os
+import re
 from onot.generating.html_resource import *
 from datetime import datetime
 
@@ -10,7 +14,15 @@ class Generator():
 
     def __init__(self):
         print("debug:" + "Html class")
-    
+
+    def convert_license_expression(self, license_name):
+        splited = re.split(r'OR|AND|WITH', str(license_name))
+        licenses = list(map(lambda license: license.replace("(", "").replace(")", "").strip(), splited))
+        license_component = license_name
+        for license in licenses:
+            license_component = str(license_component).replace(str(license), '<a href="#' + str(license) + '">' + str(license) + '</a>')
+        return license_component
+
     def make_html_code(self, doc):
         title = doc['name']
         intro = 'A portion of this ' +  \
@@ -32,7 +44,7 @@ class Generator():
                 " target="_blank">
                 """ + name_version + "</a>"
             body_component += TABLE_ROW_2
-            body_component += '<a href="#' + str(component['licenseConcluded']) + '">' + str(component['licenseConcluded']) + '</a>'
+            body_component += self.convert_license_expression(component['licenseConcluded'])
             body_component += TABLE_ROW_3
             body_component += str(component['copyrightText'])
             body_component += TABLE_CLOSE

--- a/onot/parsing/spdx_license.py
+++ b/onot/parsing/spdx_license.py
@@ -1,33 +1,57 @@
 #!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: Copyright 2022 SK TELECOM CO., LTD. <haksung@sk.com>
+# SPDX-FileCopyrightText: Copyright (c) 2022 Kakao Corp. https://www.kakaocorp.com
+#
 # SPDX-License-Identifier: Apache-2.0
+
 import requests
 
+SPDX_LICENSE_URL_PREFIX = "https://spdx.org/licenses/"
 SPDX_LICENSE_JSON_URL = "https://spdx.org/licenses/licenses.json"
+SPDX_LICENSE_EXCEPTION_JSON_URL = "https://spdx.org/licenses/exceptions.json"
 
 class SPDX_License():
 
     def __init__(self):
         print("debug:" + "SPDX_License")
         self.spdx_license_list = []
-    
+        self.spdx_license_exception_list = []
+
     def get_spdx_license_list(self):
         r = requests.get(SPDX_LICENSE_JSON_URL)
         self.spdx_license_list = r.json()
+
+    def get_spdx_license_exception_list(self):
+        r = requests.get(SPDX_LICENSE_EXCEPTION_JSON_URL)
+        self.spdx_license_exception_list = r.json()
     
     def get_spdx_license_detailsUrl(self, license_id):
         print("debug:" + "licenseid - " + license_id)
         if not self.spdx_license_list: # list is empty
             self.get_spdx_license_list()
+        if not self.spdx_license_exception_list: # list is empty
+            self.get_spdx_license_exception_list()
+
         for spdx_license in self.spdx_license_list['licenses']:
             if spdx_license['licenseId'] == license_id:
                 return spdx_license['detailsUrl']
+        for spdx_license_exception in self.spdx_license_exception_list['exceptions']:
+            if spdx_license_exception['licenseExceptionId'] == license_id:
+                return SPDX_LICENSE_URL_PREFIX + str(spdx_license_exception['reference']).replace("./", "")
+
         return None
     
     def get_spdx_license_details(self, details_url):
         r = requests.get(details_url)
         detalis_license = r.json()
-        return detalis_license
 
-    
+        # convert to license form if detalis_license is license exception
+        if "licenseId" not in detalis_license:
+            detalis_license['licenseId'] = detalis_license['licenseExceptionId']
+        if 'licenseText' not in detalis_license:
+            detalis_license['licenseText'] = detalis_license['licenseExceptionText']
+        if 'licenseTextHtml' not in detalis_license:
+            detalis_license['licenseTextHtml'] = detalis_license['exceptionTextHtml']
+
+        return detalis_license

--- a/test/test_get_spdx_license.py
+++ b/test/test_get_spdx_license.py
@@ -1,0 +1,30 @@
+# !/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright 2022 SK TELECOM CO., LTD. <haksung@sk.com>
+# SPDX-FileCopyrightText: Copyright (c) 2022 Kakao Corp. https://www.kakaocorp.com
+#
+# SPDX-License-Identifier: Apache-2.0
+import unittest
+from onot.parsing import spdx_license
+
+class TestGetSPDXLicenseCase(unittest.TestCase):
+    # license and license exception from spdx-spec/v2.3
+    # https://spdx.github.io/spdx-spec/v2.3/SPDX-license-list/#a1-licenses-with-short-identifiers
+    # https://spdx.github.io/spdx-spec/v2.3/SPDX-license-list/#a2-exceptions-list
+    licenses = ['Apache-2.0', 'BSD-3-Clause', 'EPL-2.0', 'LGPL-2.1-only', 'MPL-2.0',
+                'Autoconf-exception-2.0', 'Bison-exception-2.2', 'GCC-exception-2.0']
+
+    def setUp(self):
+        self.instance = spdx_license.SPDX_License()
+
+    def tearDown(self):
+        # self.instance.dispose()
+        del self.instance
+
+    def test_result(self):
+        for license in self.licenses:
+            with self.subTest(license=license):
+                details_url = self.instance.get_spdx_license_detailsUrl(license)
+                license_details = self.instance.get_spdx_license_details(details_url)
+                self.assertTrue(license_details['licenseId'] is not None or license_details['licenseExceptionId'] is not None)
+


### PR DESCRIPTION
안녕하세요~ 카카오 로저스입니다 :)
 
Dual License를 표기 처리한 PR입니다. https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/#d4-composite-license-expressions 를 참고하였습니다.
1. AND, OR, WITH, 괄호 표기 처리를 했습니다. 다음 사진과 같이 보여지며 각 라이선스를 클릭하면 해당 라이선스 정보로 이동합니다. `(LGPL-2.1-or-later OR BSD-3-Clause)` 처럼 처음과 끝이 괄호로 감싸져있는 경우에만 괄호를 제거를 했습니다.
   <img width="589" alt="image" src="https://user-images.githubusercontent.com/26464475/210754658-c9768c60-bd4f-4f3a-954a-ac0013f12044.png">
2. WITH 뒤에 오는 license exception 정보를 가져오고 이 exception 정보를 License 섹션에 포함시켰습니다. (따로 License Exception 섹션을 만들까 고민했다가 그냥 License 섹션에 포함했습니다. 따로 섹션을 만드는게 나으시다면 말씀해주세요) 
3. 같은 이름의 license라면 한 번만 license details 를 가져오도록 수정했습니다.
4. 라이선스 정보를 추출하는 메서드 크기가 커져서 메서드 추출을 했습니다.

수정사항이 필요하시면 언제든지 말씀해주세요.
감사합니다^^