### PR TITLE
[feat] Resolves #22 (Encoding error while installing in Windows 10)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import setuptools
 
 VERSION = '1.0.0'
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
- Set encoding as UTF-8 when opening README.md file in setup.py
- This resolves #22 