### PR TITLE
ci(2.0): GitHub Actions 액션을 Node 24 런타임으로 상향

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install ruff
@@ -28,8 +28,8 @@ jobs:
         python: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
       - run: pip install -e ".[spdx,cyclonedx,excel,api,dev]"
@@ -39,8 +39,8 @@ jobs:
   test-pdf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: install WeasyPrint native deps
@@ -51,11 +51,11 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -72,14 +72,14 @@ jobs:
         os: [windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - run: pip install -e ".[spdx,cyclonedx,excel,api]" pyinstaller
@@ -91,7 +91,7 @@ jobs:
       # 1차 미서명(D-016). 정식 배포 시 서명/공증 secrets 추가.
       # cwd가 electron/이므로 config는 그 기준 상대경로
       - run: pnpm -C electron exec electron-builder --config electron-builder.yml
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: onot-${{ matrix.os }}
           path: electron/dist-electron/
@@ -104,14 +104,14 @@ jobs:
         os: [windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - run: pip install -e ".[spdx,cyclonedx,excel,api]"
@@ -139,7 +139,7 @@ jobs:
       BLACKDUCK_URL: ${{ secrets.BLACKDUCK_URL }}
       BLACKDUCK_API_TOKEN: ${{ secrets.BLACKDUCK_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Black Duck Detect
         if: env.BLACKDUCK_URL != ''
         shell: bash


### PR DESCRIPTION
## 배경
PR #28 CI 로그에서 **Node.js 20 액션 deprecation 경고**가 확인됐다(2026-09-16 runner에서 Node 20 제거 예정). 지금 깨지진 않지만 선제적으로 Node 24 런타임 액션으로 올린다.

## 변경
모든 액션을 Node 24 메이저로 상향. 우리 사용 패턴에 breaking 없음을 릴리스 노트로 확인:
- `actions/checkout` v4 → v6 (v6의 cred 분리 저장은 읽기 전용 권한/no-push라 무관)
- `actions/setup-python` v5 → v6
- `actions/setup-node` v4 → v6
- `actions/upload-artifact` v4 → v7 (name/path 호환, direct-upload는 opt-in)
- `pnpm/action-setup` v4 → v6 (`version: 10` 입력 그대로 지원)

## 검증
- ci.yml YAML 파싱 OK
- 이 PR의 CI 실행 자체가 새 액션 버전의 동작 검증(18잡 매트릭스)

🤖 Generated with [Claude Code](https://claude.com/claude-code)