### PR TITLE
ci(2.0): build-desktop가 게시 시도하지 않도록 --publish never

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,10 @@ jobs:
       - run: pnpm -C electron install
       # 1차 미서명(D-016). 정식 배포 시 서명/공증 secrets 추가.
       # cwd가 electron/이므로 config는 그 기준 상대경로
-      - run: pnpm -C electron exec electron-builder --config electron-builder.yml
+      # 이 잡은 빌드 검증 전용 — electron-builder.yml의 publish 설정 때문에 CI(push)에서
+      # 게시를 시도해 GH_TOKEN을 요구하지 않도록 --publish never로 못 박는다. 실제 게시는
+      # GH_TOKEN을 가진 release.yml(--publish always)만 담당한다.
+      - run: pnpm -C electron exec electron-builder --config electron-builder.yml --publish never
       - uses: actions/upload-artifact@v7
         with:
           name: onot-${{ matrix.os }}


### PR DESCRIPTION
## 문제

`electron-builder.yml`에 `publish: github`를 추가한 뒤로 main push CI가 실패했다. 같은 코드가 PR(pull_request)에서는 통과한다.

원인: 빌드 검증 전용인 `build-desktop` 잡이 CI(push) 환경에서 electron-builder의 publish 설정 때문에 게시를 시도하는데, 이 잡엔 `GH_TOKEN`이 없어 `GitHub Personal Access Token is not set`으로 실패한다. PR에서는 electron-builder가 PR 컨텍스트를 감지해 게시를 끄므로 통과했다.

## 수정

`build-desktop`의 electron-builder 호출에 `--publish never`를 명시한다. 검증 잡은 절대 게시하지 않는다. 실제 게시는 `GH_TOKEN`을 가진 `release.yml`(`--publish always`)만 담당한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)