### PR TITLE
chore(1.1): README 영문화 + 버전 1.1.0 + TrustedOSS DevSecOps 보안 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,29 +132,3 @@ jobs:
           for i in $(seq 1 30); do curl -sf http://localhost:4173 >/dev/null && break; sleep 1; done
           node --test electron/test/*.test.mjs
           pnpm -C electron run e2e
-
-  security:
-    needs: [lint, test-core]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    # secrets는 if 표현식에서 직접 못 쓰므로 env로 옮겨 검사한다
-    env:
-      BLACKDUCK_URL: ${{ secrets.BLACKDUCK_URL }}
-      BLACKDUCK_API_TOKEN: ${{ secrets.BLACKDUCK_API_TOKEN }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Black Duck Detect
-        if: env.BLACKDUCK_URL != ''
-        shell: bash
-        run: |
-          bash <(curl -s -L https://detect.synopsys.com/detect10.sh) \
-            --blackduck.url="$BLACKDUCK_URL" \
-            --blackduck.api.token="$BLACKDUCK_API_TOKEN" \
-            --blackduck.trust.cert=true \
-            --detect.project.name=onot \
-            --detect.project.version.name=2.0.0 \
-            --detect.detector.search.depth=2 \
-            --detect.project.version.distribution=SAAS
-      - name: notice when Black Duck is not configured
-        if: env.BLACKDUCK_URL == ''
-        run: echo "Black Duck secrets not set — skipping scan."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: release
 
 # v* 태그를 밀면 윈도우/macOS 설치 파일을 빌드해 GitHub Releases에 게시한다.
-# 예: git tag v2.0.0 && git push origin v2.0.0
+# 예: git tag v1.1.0 && git push origin v1.1.0
 on:
   push:
     tags: ["v*"]

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,88 @@
+name: security
+
+# TrustedOSS DevSecOps 가이드(https://trustedoss.github.io/devsecops/intro)에서
+# 권장하는 보안 검사를 CI에 적용한다. Black Duck(상용 SCA)을 대체한다.
+#   - Secret 탐지: Gitleaks
+#   - SAST: CodeQL + Semgrep
+#   - SCA: SBOM(CycloneDX) 생성 + grype 취약점 스캔
+# 컨테이너(Trivy)·IaC(Checkov)·DAST(ZAP)는 이 저장소에 대상(Dockerfile/IaC/배포
+# 웹 엔드포인트)이 없어 제외했다.
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+  schedule:
+    - cron: "0 2 * * 1" # 매주 월요일 02:00 UTC — CodeQL 정기 전수 스캔
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    name: Secret scanning (Gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # 커밋 히스토리 전체를 스캔
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  sast-semgrep:
+    name: SAST (Semgrep)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: semgrep/semgrep-action@v1
+        with:
+          config: >-
+            p/owasp-top-ten
+            p/security-audit
+            p/secrets
+
+  sast-codeql:
+    name: SAST (CodeQL)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  sca:
+    name: SCA (SBOM + grype)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+      - name: Scan SBOM (grype)
+        uses: anchore/scan-action@v6
+        with:
+          sbom: sbom.cdx.json
+          fail-build: true
+          severity-cutoff: high # High 이상 취약점에서 빌드 차단
+      - name: Upload SBOM
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cdx.json

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,9 +26,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # 커밋 히스토리 전체를 스캔
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # gitleaks-action은 조직 계정에 유료 라이선스를 요구하므로,
+      # MIT 라이선스인 gitleaks CLI 바이너리를 직접 받아 실행한다.
+      - name: Install gitleaks
+        run: |
+          VERSION=8.18.4
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+      - name: Run gitleaks
+        run: gitleaks detect --source . --redact --no-banner --verbose
 
   sast-semgrep:
     name: SAST (Semgrep)

--- a/README.md
+++ b/README.md
@@ -4,90 +4,80 @@
 [![Download for Windows](https://img.shields.io/badge/Download-Windows%20installer-0078D6?logo=windows&logoColor=white)](https://github.com/sktelecom/onot/releases/latest)
 [![Downloads](https://img.shields.io/github/downloads/sktelecom/onot/total)](https://github.com/sktelecom/onot/releases)
 
-`onot`은 SBOM 문서로부터 오픈소스 고지문(OSS Notice)을 자동 생성하는 도구입니다.
-[SPDX](https://spdx.dev) 2.x(JSON/YAML/Tag-Value/RDF), [CycloneDX](https://cyclonedx.org)(JSON/XML),
-Excel을 입력으로 받아 HTML, Text, Markdown, PDF 고지문을 만듭니다. Kakao와 SK telecom이 함께
-개발하는 오픈소스 프로젝트입니다.
+`onot` generates open source software notices (OSS Notice) from SBOM documents.
+It reads [SPDX](https://spdx.dev) 2.x (JSON/YAML/Tag-Value/RDF),
+[CycloneDX](https://cyclonedx.org) (JSON/XML), and Excel, and produces HTML, Text,
+Markdown, and PDF notices. License texts are bundled, so it runs fully offline
+(air-gapped) — your SBOM never leaves the machine. Jointly developed by Kakao and
+SK telecom.
 
-> 2.0 재작성: 타입 안전한 Python 코어(표준 SPDX 라이브러리 재사용) + CLI + 로컬 API + 설치형
-> 데스크톱(Electron). 라이선스 전문을 번들해 **네트워크 없이(에어갭) 동작**합니다.
+![onot app](docs/images/04-preview.png)
 
-## 다운로드 (Windows)
+> Korean user guide / 사용 가이드: [docs/USER_GUIDE.md](docs/USER_GUIDE.md)
 
-개발 환경을 따로 꾸리지 않아도 됩니다. [Releases](https://github.com/sktelecom/onot/releases)
-페이지에서 최신 `onot-Setup-x.y.z.exe`를 받아 실행하면 설치됩니다. 앱을 열고 SBOM 파일을
-끌어다 놓으면 고지문을 미리 보고 내려받을 수 있습니다. 모든 처리는 로컬에서 이뤄지며 SBOM이
-외부로 나가지 않습니다.
+## Download (desktop app)
 
-![onot 앱 화면](docs/images/04-preview.png)
+No setup required. Grab the latest installer from
+[Releases](https://github.com/sktelecom/onot/releases), open the app, and drop in an
+SBOM file to preview and download a notice — Windows (`onot-Setup-x.y.z.exe`) and
+macOS (`.dmg`).
 
-화면별로 따라 하는 자세한 설명은 [사용 가이드](docs/USER_GUIDE.md)에 스크린샷과 함께 정리해
-두었습니다.
-
-설치 파일에 코드 서명이 되어 있지 않아 첫 실행 때 Windows SmartScreen이 "알 수 없는 게시자"
-경고를 띄울 수 있습니다. 이때 `추가 정보`를 누른 뒤 `실행`을 선택하면 설치가 진행됩니다.
-
-macOS 사용자는 같은 Releases 페이지에서 `.dmg`를 받습니다. 서명이 없어 첫 실행 시
-앱을 우클릭한 뒤 `열기`를 선택해야 Gatekeeper를 통과합니다.
-
-## 설치 (개발용)
-
-소스에서 직접 빌드하려는 경우입니다.
-
-```bash
-python -m venv .venv && . .venv/bin/activate
-pip install -e ".[spdx,cyclonedx,excel,api]"
-```
+The installers are unsigned. On first launch Windows SmartScreen may warn about an
+"unknown publisher" — choose **More info → Run anyway**. On macOS, right-click the app
+and choose **Open** to pass Gatekeeper.
 
 ## CLI
 
 ```bash
-# SBOM(포맷 자동 감지) → 여러 포맷 고지문 생성
+pip install -e ".[spdx,cyclonedx,excel,api]"
+
+# SBOM (format auto-detected) → notices in multiple formats
 onot generate -i sbom.spdx.json -f html -f markdown --output-dir ./output
 
-# 옵션
-#   -f/--format       html | text | markdown | pdf (반복 지정 가능)
-#   --lang            ko | en
-#   --config          onot.yaml (회사 정보 등)
-#   --online          번들에 없는 라이선스 전문을 원격 보충(기본은 오프라인)
-#   --stdout          단일 텍스트 포맷을 표준출력으로
+#   -f/--format   html | text | markdown | pdf (repeatable)
+#   --lang        ko | en
+#   --config      onot.yaml (company info, etc.)
+#   --online      fetch missing license texts remotely (offline by default)
+#   --stdout      write a single text format to stdout
 
-onot formats     # 지원 출력 포맷
+onot formats   # supported output formats
 onot version
 ```
 
-입력 포맷은 확장자와 내용으로 자동 감지합니다(SPDX JSON과 CycloneDX JSON 구분 포함).
-PDF는 `pip install ".[pdf]"`(WeasyPrint)가 필요하며, 데스크톱 앱에서는 내장 변환을 씁니다.
+Input format is auto-detected by extension and content (including SPDX JSON vs.
+CycloneDX JSON). PDF output needs `pip install ".[pdf]"` (WeasyPrint); the desktop app
+uses a built-in converter.
 
-## 로컬 API (사이드카)
+## Local API (sidecar)
 
 ```bash
 onot-sidecar --port 8765
-# POST /api/parse   (업로드 → 파싱 결과)
-# POST /api/render  (업로드 + 포맷/언어/회사 → 고지문)
+# POST /api/parse    upload → parse result
+# POST /api/render   upload + format/lang/company → notice
 # GET  /api/formats, GET /healthz
 ```
 
-## 데스크톱 앱 (Electron)
+## Desktop app (Electron)
 
 ```bash
 pnpm -C frontend install && pnpm -C frontend build
-pnpm -C electron install && pnpm -C electron start   # 개발 실행
-pnpm -C electron run dist                            # 패키징(.dmg/.exe/.AppImage)
+pnpm -C electron install && pnpm -C electron start   # dev
+pnpm -C electron run dist                            # package (.dmg/.exe/.AppImage)
 ```
 
-업로드 → 미리보기 → 다운로드. 모든 처리가 로컬에서 수행되어 SBOM이 외부로 나가지 않습니다.
+Upload → preview → download. All processing is local; the SBOM never leaves the machine.
 
-## 개발
+## Development
 
 ```bash
-bash .claude/gate.sh   # lint + pytest(cov≥90) + frontend build/test + electron 사이드카 테스트
+bash .claude/gate.sh   # lint + pytest (cov ≥ 90) + frontend build/test + electron sidecar test
 ```
 
-라이선스 데이터 갱신: `python scripts/update_license_data.py` (SPDX license-list-data 번들).
-설계·결정 문서는 `docs/2.0/`(TRACEABILITY.md, DECISIONS.md) 참고. 1.x 코드는 제거됨(이력은 git history 참고, D-017).
+Refresh license data with `python scripts/update_license_data.py` (bundles SPDX
+license-list-data). Design and decision records live in `docs/2.0/`
+(TRACEABILITY.md, DECISIONS.md).
 
-## Maintainer
+## Maintainers
 
 | Name | Company | Email |
 |--|--|--|

--- a/docs/2.0/DECISIONS.md
+++ b/docs/2.0/DECISIONS.md
@@ -153,7 +153,8 @@
 ## D-017 — M9 CI + 1.x legacy 보존
 
 - **날짜**: 2026-06-02 / **근거**: M9
-- **CI(`.github/workflows/ci.yml`)**: 1.x `python-app.yml`(py3.8, PyQt exe, flake8 오타)을 교체. 잡: lint(ruff), test-core(ubuntu/windows/macos × py3.11–3.13, cov≥90), test-pdf(ubuntu+pango), frontend(build+vitest), build-desktop(win/mac electron-builder + PyInstaller 사이드카), e2e-desktop(win/mac, node 사이드카 테스트 + Playwright-electron). (Black Duck Detect 보안 잡은 제거됨.)
+- **CI(`.github/workflows/ci.yml`)**: 1.x `python-app.yml`(py3.8, PyQt exe, flake8 오타)을 교체. 잡: lint(ruff), test-core(ubuntu/windows/macos × py3.11–3.13, cov≥90), test-pdf(ubuntu+pango), frontend(build+vitest), build-desktop(win/mac electron-builder + PyInstaller 사이드카), e2e-desktop(win/mac, node 사이드카 테스트 + Playwright-electron).
+- **보안 CI(`.github/workflows/security.yml`)**: 상용 Black Duck Detect를 제거하고 [TrustedOSS DevSecOps](https://trustedoss.github.io/devsecops/intro) 권장 오픈소스 스택으로 대체했다. 잡은 네 가지다. secret-scan은 Gitleaks로 시크릿을 탐지한다. sast-semgrep은 p/owasp-top-ten, p/security-audit, p/secrets 룰셋으로 정적 분석한다. sast-codeql은 python과 javascript-typescript를 분석하며 주간 cron으로 정기 전수 스캔한다. sca는 anchore/sbom-action으로 CycloneDX SBOM을 만든 뒤 anchore/scan-action(grype)으로 스캔해 High 이상 취약점에서 빌드를 차단한다. 컨테이너(Trivy), IaC(Checkov), DAST(ZAP)는 대상인 Dockerfile, IaC, 배포 웹 엔드포인트가 없어 제외했다.
 - **Playwright-electron E2E**(electron/e2e/app.e2e.mjs): 실제 앱 기동 → 사이드카 파싱 → 미리보기 풀 플로우. CI(Win/mac)에서 실행. dev 사이드카 python은 `ONOT_SIDECAR_PYTHON`로 재정의(CI는 시스템 python).
 - **1.x legacy 보존**: `legacy/onot/`·`legacy/test/`를 이번 릴리스에서 제거하지 않고 참조용으로 보존(import 경로 분리됨, src-layout과 충돌 없음). 완전 제거는 2.0 안정화 후 후속 결정. acceptance 9.9의 "1.x 잔재 처리"를 보존으로 명시 결정.
 - **영향**: §8.4 CI, 최종 수용 기준.

--- a/docs/2.0/DECISIONS.md
+++ b/docs/2.0/DECISIONS.md
@@ -153,7 +153,7 @@
 ## D-017 — M9 CI + 1.x legacy 보존
 
 - **날짜**: 2026-06-02 / **근거**: M9
-- **CI(`.github/workflows/ci.yml`)**: 1.x `python-app.yml`(py3.8, PyQt exe, flake8 오타)을 교체. 잡: lint(ruff), test-core(ubuntu/windows/macos × py3.11–3.13, cov≥90), test-pdf(ubuntu+pango), frontend(build+vitest), build-desktop(win/mac electron-builder + PyInstaller 사이드카), e2e-desktop(win/mac, node 사이드카 테스트 + Playwright-electron), security(Black Duck Detect, secrets 있을 때만). secrets는 if에서 직접 못 쓰므로 env 경유.
+- **CI(`.github/workflows/ci.yml`)**: 1.x `python-app.yml`(py3.8, PyQt exe, flake8 오타)을 교체. 잡: lint(ruff), test-core(ubuntu/windows/macos × py3.11–3.13, cov≥90), test-pdf(ubuntu+pango), frontend(build+vitest), build-desktop(win/mac electron-builder + PyInstaller 사이드카), e2e-desktop(win/mac, node 사이드카 테스트 + Playwright-electron). (Black Duck Detect 보안 잡은 제거됨.)
 - **Playwright-electron E2E**(electron/e2e/app.e2e.mjs): 실제 앱 기동 → 사이드카 파싱 → 미리보기 풀 플로우. CI(Win/mac)에서 실행. dev 사이드카 python은 `ONOT_SIDECAR_PYTHON`로 재정의(CI는 시스템 python).
 - **1.x legacy 보존**: `legacy/onot/`·`legacy/test/`를 이번 릴리스에서 제거하지 않고 참조용으로 보존(import 경로 분리됨, src-layout과 충돌 없음). 완전 제거는 2.0 안정화 후 후속 결정. acceptance 9.9의 "1.x 잔재 처리"를 보존으로 명시 결정.
 - **영향**: §8.4 CI, 최종 수용 기준.

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onot-desktop",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "main": "main.mjs",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onot-frontend",
   "private": true,
-  "version": "2.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "onot"
-version = "2.0.0.dev0"
+version = "1.1.0.dev0"
 description = "Generate open source software notices from SBOM/SPDX documents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/onot/__init__.py
+++ b/src/onot/__init__.py
@@ -1,3 +1,3 @@
-"""onot 2.0 — open source software notice generator from SBOM/SPDX documents."""
+"""onot — open source software notice generator from SBOM/SPDX documents."""
 
-__version__ = "2.0.0.dev0"
+__version__ = "1.1.0.dev0"

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -169,4 +169,4 @@ def test_formats_command():
 def test_version_command():
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
-    assert result.output.strip().startswith("2.")
+    assert result.output.strip().startswith("1.")

--- a/tests/e2e/test_slice.py
+++ b/tests/e2e/test_slice.py
@@ -58,7 +58,7 @@ def test_cli_generate(tmp_path):
 def test_cli_version():
     result = CliRunner().invoke(app, ["version"])
     assert result.exit_code == 0
-    assert result.output.strip().startswith("2.")
+    assert result.output.strip().startswith("1.")
 
 
 def test_output_filename():

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2,4 +2,4 @@ import onot
 
 
 def test_version():
-    assert onot.__version__.startswith("2.")
+    assert onot.__version__.startswith("1.")


### PR DESCRIPTION
## 요약

- **README 영문 간소화**: 핵심만 영어로 재작성하고 대표 스크린샷은 유지. 한글 사용 가이드(`docs/USER_GUIDE.md`)는 링크로 연결.
- **버전 2.0.0 → 1.1.0**: 1.0.0에서 한 번에 메이저를 올린 것을 마이너 증가로 조정. `pyproject.toml`, `src/onot/__init__.py`, `frontend/package.json`, `electron/package.json`, release 태그 예시, 버전 단언 테스트 3개 반영.
- **상용 Black Duck 제거 → TrustedOSS DevSecOps 도입**: `ci.yml`의 Black Duck Detect 잡을 제거하고, [TrustedOSS DevSecOps](https://trustedoss.github.io/devsecops/intro) 권장 오픈소스 보안 스택을 `security.yml`로 추가.

## security.yml 구성

| 잡 | 도구 | 정책 |
|--|--|--|
| secret-scan | Gitleaks | 히스토리 전체 스캔 |
| sast-semgrep | Semgrep | p/owasp-top-ten, p/security-audit, p/secrets |
| sast-codeql | CodeQL | python + javascript-typescript, 주간 cron |
| sca | anchore SBOM + grype | CycloneDX SBOM 생성 후 grype 스캔, High 이상에서 빌드 차단 |

컨테이너(Trivy)·IaC(Checkov)·DAST(ZAP)는 대상(Dockerfile/IaC/배포 웹 엔드포인트)이 없어 제외.

## 후속
- 더 이상 쓰지 않는 `BLACKDUCK_URL`/`BLACKDUCK_API_TOKEN` secret 정리 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)