### PR TITLE
ci(1.1): SCA grype에 vitest 취약점 무시 규칙 추가

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,17 @@
+# grype 취약점 스캔 설정 — CI의 SCA 잡(.github/workflows/security.yml)에서 사용한다.
+# High 이상 심각도에서 빌드를 차단한다.
+fail-on-severity: high
+
+ignore:
+  # GHSA-5xrq-8626-4rwp (Critical) — Vitest UI 서버가 수신 대기 중일 때 임의 파일
+  # 읽기/실행이 가능한 취약점. 다음 근거로 무시한다(다른 vitest 취약점은 계속 차단).
+  #   - vitest는 프론트엔드 테스트 전용 devDependency로, 배포물(Electron 앱·파이썬
+  #     패키지)이나 빌드 산출물(vite build 결과)에 포함되지 않는다.
+  #   - 취약점은 `vitest --ui` UI 서버가 떠 있을 때만 성립하나, CI는 `vitest run`만
+  #     실행하고 UI 서버를 띄우지 않는다 → 실제 노출 경로 없음.
+  #   - 패치는 vitest 4.1.0부터 제공되지만 vitest 4는 vite 6+를 요구해 프로덕션 빌드
+  #     체인(현재 vite 5)까지 강제 업그레이드를 유발한다. 업그레이드는 별도 작업으로 분리.
+  - vulnerability: GHSA-5xrq-8626-4rwp
+    package:
+      name: vitest
+      type: npm


### PR DESCRIPTION
## 배경

PR #33 머지 직후, main의 `security` 워크플로 중 **SCA(SBOM + grype) 잡이 실패**했다.

원인: grype 취약점 DB가 갱신(`v6.1.4`, 2026-06-02 빌드)되며 프론트엔드 테스트 러너 `vitest@2.1.9`의 **GHSA-5xrq-8626-4rwp (Critical)** 이 High 게이트에 매칭됨. PR #33 실행 시점 DB에는 없었다.

## 조치

TrustedOSS SCA 가이드가 명시한 대로 근거를 기록한 `.grype.yaml` 무시 규칙으로 처리.

근거:
- `vitest`는 프론트엔드 테스트 전용 **devDependency** — 배포물(Electron 앱·파이썬 패키지)이나 빌드 산출물에 포함되지 않음.
- 취약점은 `vitest --ui` **UI 서버가 수신 대기 중일 때만** 성립. CI는 `vitest run`만 실행하고 UI 서버를 띄우지 않음 → 실제 노출 경로 없음.
- 패치(4.1.0)는 **vite 6+를 요구**해 프로덕션 빌드 체인(현재 vite 5)까지 강제 업그레이드를 유발 → 별도 작업으로 분리.

무시 규칙은 해당 GHSA·패키지에 한정되며, 다른 High+ 취약점은 계속 빌드를 차단한다. 로컬에서 CI와 동일한 SBOM으로 grype 통과를 확인했다.

## 후속(별도)
- `vitest` 4.x + `vite` 6.x 업그레이드를 별도 PR로 진행해 무시 규칙 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)