### PR TITLE
chore(1.1): 글로벌 OSS 프로젝트 정비 — 커뮤니티 헬스 파일·메타데이터·자동화

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners for everything in the repo.
+# These users are requested for review on every pull request.
+*       @HyunMinH @haksungjang

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report a problem with onot
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! For security vulnerabilities,
+        please follow [SECURITY.md](../blob/main/SECURITY.md) instead of opening a public issue.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: |
+        How can we reproduce it? A minimal SBOM/SPDX/CycloneDX/Excel input file
+        (or a snippet) is extremely helpful.
+      placeholder: |
+        1. Run `onot generate -i ...`
+        2. ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: onot version
+      description: Output of `onot version`, or the desktop app version.
+      placeholder: "1.1.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: How are you using onot?
+      options:
+        - CLI
+        - Local API (onot-sidecar)
+        - Desktop app
+        - Python library
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "Windows 11 / macOS 14 / Ubuntu 24.04"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or error output
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/sktelecom/onot/security/advisories/new
+    about: Please report security issues privately, not as public issues. See SECURITY.md.
+  - name: Question or usage help
+    url: https://github.com/sktelecom/onot/issues
+    about: Search existing issues first; open a new one with the bug or feature template if needed.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest an idea or improvement for onot
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the use case or pain point. "I'm always frustrated when..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like onot to do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've thought about.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which part of onot?
+      multiple: true
+      options:
+        - Input formats (SPDX / CycloneDX / Excel)
+        - Output formats (HTML / Text / Markdown / PDF)
+        - CLI
+        - Local API (onot-sidecar)
+        - Desktop app
+        - License resolution / data

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- Thanks for contributing to onot! Please fill in the sections below. -->
+
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Related issues
+
+<!-- e.g. Closes #123 -->
+
+## Changes
+
+<!-- Bullet the key changes. -->
+
+-
+
+## Checklist
+
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] Tests added/updated and coverage stays ≥ 90%
+- [ ] `bash .claude/gate.sh` passes locally (lint + tests + frontend/electron)
+- [ ] Docs updated (`README.md` / `docs/USER_GUIDE.md`) if behavior changed
+- [ ] `CHANGELOG.md` entry added under `[Unreleased]`

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  # Python core
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      python-minor:
+        update-types: ["minor", "patch"]
+
+  # Frontend (React/Vite, pnpm)
+  - package-ecosystem: npm
+    directory: "/frontend"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      frontend-minor:
+        update-types: ["minor", "patch"]
+
+  # Desktop (Electron, pnpm)
+  - package-ecosystem: npm
+    directory: "/electron"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      electron-minor:
+        update-types: ["minor", "patch"]
+
+  # GitHub Actions used in CI/security/release workflows
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+This release is a full rewrite of onot as a type-safe Python core with a React UI,
+shipped as an installable desktop app. It is the successor to the 1.0.0 PyQt-based
+generator.
+
+### Added
+
+- Python core that reads SPDX 2.x (JSON/YAML/Tag-Value/RDF), CycloneDX (JSON/XML),
+  and Excel, with input format auto-detection.
+- Output renderers for HTML, Text, Markdown, and PDF, in English and Korean.
+- Bundled SPDX license texts so notices can be generated fully offline (air-gapped);
+  optional `--online` mode fills in any missing texts.
+- `onot` CLI (`generate`, `formats`, `version`) and a local API sidecar
+  (`onot-sidecar`) exposing `/api/parse`, `/api/render`, and `/api/formats`.
+- Electron desktop app (Windows `.exe`, macOS `.dmg`) with a drag-and-drop
+  upload → preview → download flow; all processing stays local.
+- Security CI based on the TrustedOSS DevSecOps guidance: secret scanning (Gitleaks),
+  SAST (CodeQL, Semgrep), and SCA (CycloneDX SBOM + grype).
+- Community health files: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`,
+  issue/PR templates, and `CODEOWNERS`.
+
+### Changed
+
+- Upgraded the frontend toolchain to Vite 6 and Vitest 4, and the desktop runtime to
+  Electron 42 (off the end-of-life Electron 33), resolving known advisories.
+- Replaced the proprietary Black Duck scan in CI with the open-source DevSecOps stack.
+
+## [1.0.0] - 2023-03-21
+
+- Initial public release: PyQt-based desktop generator that produced OSS notices
+  from SPDX documents.
+
+[Unreleased]: https://github.com/sktelecom/onot/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/sktelecom/onot/releases/tag/1.0.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in the onot
+community a harassment-free experience for everyone, regardless of age, body size,
+visible or invisible disability, ethnicity, sex characteristics, gender identity and
+expression, level of experience, education, socio-economic status, nationality,
+personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standard
+
+This project adopts the **[Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)**
+as its code of conduct. Please read the full text at the link above. It describes
+the behavior we expect, the responsibilities of maintainers, the scope of this
+policy, and the enforcement guidelines we follow.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported
+to the project maintainers listed in the [README](README.md#maintainers). All
+complaints will be reviewed and investigated promptly and fairly. Maintainers are
+obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1. Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to onot
+
+Thanks for your interest in contributing! onot is an open source project jointly
+developed by Kakao and SK telecom. This guide explains how to set up your
+environment and get a change merged.
+
+By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Project layout
+
+onot is a Python core with a React UI packaged as an installable desktop app.
+
+- `src/onot/` — Python core (parsing, license resolution, rendering, CLI, local API)
+- `frontend/` — React + Vite UI (Vitest tests)
+- `electron/` — Electron desktop shell (Playwright E2E)
+- `tests/` — Python test suite
+- `docs/` — user guide and design/decision records (`docs/2.0/`)
+
+## Development setup
+
+### Python core
+
+```bash
+python -m venv .venv && . .venv/bin/activate
+pip install -e ".[spdx,cyclonedx,excel,api,pdf,dev]"
+```
+
+### Frontend & desktop
+
+```bash
+pnpm -C frontend install
+pnpm -C electron install
+```
+
+## Running checks
+
+Before opening a pull request, run the full quality gate:
+
+```bash
+bash .claude/gate.sh   # ruff + pytest (coverage ≥ 90) + frontend build/test + electron tests
+```
+
+Or run pieces individually:
+
+```bash
+ruff check src tests && ruff format --check src tests   # lint/format
+pytest --cov=onot --cov-fail-under=90                   # Python tests
+pnpm -C frontend test                                   # UI unit tests
+pnpm -C electron test                                   # sidecar lifecycle tests
+```
+
+CI runs the same checks on Linux, macOS, and Windows across Python 3.11–3.13, plus
+SAST (CodeQL, Semgrep), SCA (SBOM + grype), and secret scanning. All checks must
+pass before a PR can be merged.
+
+## Pull request guidelines
+
+- **Branch** off `main` (e.g. `feat/...`, `fix/...`, `chore/...`, `docs/...`).
+- **Keep changes focused.** One logical change per PR is easier to review.
+- **Add tests** for new behavior and keep coverage at or above 90%.
+- **Commit messages** follow [Conventional Commits](https://www.conventionalcommits.org/),
+  e.g. `feat(render): add Markdown table layout` or `fix(ingest): handle empty SPDX relationships`.
+- **Update docs** (`README.md`, `docs/USER_GUIDE.md`) when behavior changes, and add a
+  `CHANGELOG.md` entry under `[Unreleased]`.
+
+## Reporting bugs and requesting features
+
+Use the [issue templates](https://github.com/sktelecom/onot/issues/new/choose). For
+security issues, follow [SECURITY.md](SECURITY.md) instead of opening a public issue.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[Apache-2.0 License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # onot
 
+[![CI](https://github.com/sktelecom/onot/actions/workflows/ci.yml/badge.svg)](https://github.com/sktelecom/onot/actions/workflows/ci.yml)
+[![Security](https://github.com/sktelecom/onot/actions/workflows/security.yml/badge.svg)](https://github.com/sktelecom/onot/actions/workflows/security.yml)
+[![License](https://img.shields.io/github/license/sktelecom/onot)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/sktelecom/onot?sort=semver)](https://github.com/sktelecom/onot/releases/latest)
 [![Download for Windows](https://img.shields.io/badge/Download-Windows%20installer-0078D6?logo=windows&logoColor=white)](https://github.com/sktelecom/onot/releases/latest)
 [![Downloads](https://img.shields.io/github/downloads/sktelecom/onot/total)](https://github.com/sktelecom/onot/releases)
@@ -76,6 +79,13 @@ bash .claude/gate.sh   # lint + pytest (cov ≥ 90) + frontend build/test + elec
 Refresh license data with `python scripts/update_license_data.py` (bundles SPDX
 license-list-data). Design and decision records live in `docs/2.0/`
 (TRACEABILITY.md, DECISIONS.md).
+
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for how to set up
+your environment, run the checks, and open a pull request. Please also read our
+[Code of Conduct](CODE_OF_CONDUCT.md). To report a security vulnerability, follow
+[SECURITY.md](SECURITY.md) instead of opening a public issue.
 
 ## Maintainers
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are provided for the latest released version of onot. Please
+upgrade to the most recent release before reporting an issue.
+
+| Version | Supported |
+| ------- | --------- |
+| 1.1.x   | ✅        |
+| < 1.1   | ❌        |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Go to the [Security tab](https://github.com/sktelecom/onot/security) of this
+   repository.
+2. Click **Report a vulnerability** and fill in the advisory form.
+
+If you cannot use private reporting, email the maintainers listed in the
+[README](README.md#maintainers) with the subject line `onot security`.
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (a minimal SBOM or input file is very helpful).
+- The onot version (`onot version`) and your OS.
+
+## What to expect
+
+- We aim to acknowledge a report within **5 business days**.
+- We will keep you informed as we investigate and prepare a fix.
+- Once a fix is released, we will credit you in the advisory unless you prefer to
+  remain anonymous.
+
+## Scope
+
+onot processes SBOM documents entirely **locally** and bundles license texts so
+it can run offline. Reports that are especially relevant include, but are not
+limited to:
+
+- Parsing untrusted SBOM/SPDX/CycloneDX/Excel input (e.g. XML entity expansion,
+  path traversal, resource exhaustion).
+- The local API sidecar (`onot-sidecar`) and the desktop app's IPC surface.
+- Template rendering and PDF generation paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,8 +8,37 @@ version = "1.1.0.dev0"
 description = "Generate open source software notices from SBOM/SPDX documents"
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [{ name = "onot contributors" }]
+maintainers = [
+    { name = "Hyunmin Han" },
+    { name = "Haksung Jang" },
+]
+keywords = [
+    "sbom",
+    "spdx",
+    "cyclonedx",
+    "oss",
+    "open-source",
+    "license",
+    "compliance",
+    "notice",
+    "attribution",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Legal Industry",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 dependencies = [
     "pydantic[email]>=2.6",
     "pydantic-settings>=2.2",
@@ -37,6 +66,12 @@ dev = [
 all = [
     "onot[spdx,cyclonedx,excel,api]",
 ]
+
+[project.urls]
+Homepage = "https://github.com/sktelecom/onot"
+Repository = "https://github.com/sktelecom/onot"
+Issues = "https://github.com/sktelecom/onot/issues"
+Changelog = "https://github.com/sktelecom/onot/blob/main/CHANGELOG.md"
 
 [project.scripts]
 onot = "onot.cli.main:app"


### PR DESCRIPTION
글로벌 공개 오픈소스 프로젝트 관점 검토에서 나온 미비점을 우선순위로 보완한다. (P0 — 잘못 게시된 `2.0.0` 릴리스/태그 삭제 — 는 이미 별도로 처리됨.)

## P1 — 커뮤니티 헬스 파일 + 패키징 메타데이터

- `SECURITY.md` — GitHub 비공개 취약점 신고 절차(방금 도입한 DevSecOps와 짝)
- `CONTRIBUTING.md` — 개발 환경·`.claude/gate.sh`·PR 규칙(Conventional Commits)
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 채택
- 이슈/PR 템플릿(`bug_report`·`feature_request`·`config` + PR 체크리스트), `CODEOWNERS`
- `CHANGELOG.md` — Keep a Changelog 형식
- `pyproject.toml` — PEP 639 라이선스(`License-Expression: Apache-2.0`), `[project.urls]`,
  `classifiers`, `keywords`, `maintainers` 추가. sdist 빌드로 메타데이터 검증 완료

## P2 — 자동화·문서·저장소 설정

- `.github/dependabot.yml` — pip·npm(frontend/electron)·github-actions 주간 갱신(그룹화)
- `README` — CI·Security·License 배지 + Contributing 섹션(헬스 파일 링크)
- `.editorconfig`
- 저장소 설정(직접 적용): description 최신화, topics 9개, homepage URL

## 검증

- `python -m build --sdist` 성공, PKG-INFO에 License-Expression/Project-URL/Keywords 반영 확인
- dependabot.yml YAML 파싱 확인
- 로컬 게이트(ruff + pytest cov≥90 + frontend) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)