### PR TITLE
chore(1.1): PyPI 게시 자동화 + 영어 사용자 가이드 + SPDX/NOTICE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,23 @@
 name: release
 
-# v* 태그를 밀면 윈도우/macOS 설치 파일을 빌드해 GitHub Releases에 게시한다.
+# v* 태그를 밀면 윈도우/macOS 설치 파일을 빌드해 GitHub Releases에 게시하고,
+# 최종 릴리스 태그(하이픈 없는 v1.2.3)는 PyPI에도 게시한다.
 # 예: git tag v1.1.0 && git push origin v1.1.0
+#
+# PyPI 게시는 토큰 없는 Trusted Publishing(OIDC)을 쓴다. 최초 1회 PyPI에서
+# 신뢰 게시자를 등록해야 한다(Owner: sktelecom, Repo: onot, Workflow: release.yml,
+# Environment: pypi). 등록 전까지 publish-pypi 잡은 실패하지만 일반 CI에는 영향이 없다.
 on:
   push:
     tags: ["v*"]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   publish-desktop:
+    permissions:
+      contents: write # GitHub Releases에 설치파일 업로드
     strategy:
       fail-fast: false
       matrix:
@@ -49,3 +56,32 @@ jobs:
             --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    # 최종 릴리스 태그만 게시한다(rc/beta 등 하이픈 포함 태그는 데스크톱만).
+    if: ${{ !contains(github.ref_name, '-') }}
+    permissions:
+      id-token: write # OIDC Trusted Publishing
+      contents: read
+    environment:
+      name: pypi
+      url: https://pypi.org/project/onot/
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Pin package version to the git tag
+        # 태그를 단일 진실로 삼아 sdist/wheel 버전을 일치시킨다(pyproject의 .dev0 무시).
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Building onot $VERSION from tag $GITHUB_REF_NAME"
+          sed -i -E "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,22 @@ pass before a PR can be merged.
 Use the [issue templates](https://github.com/sktelecom/onot/issues/new/choose). For
 security issues, follow [SECURITY.md](SECURITY.md) instead of opening a public issue.
 
+## Releasing (maintainers)
+
+Releases are tag-driven. Pushing a `v*` tag triggers `.github/workflows/release.yml`:
+
+1. Bump `version` in `pyproject.toml`, `src/onot/__init__.py`,
+   `frontend/package.json`, and `electron/package.json`, and add a `CHANGELOG.md`
+   entry. Merge to `main`.
+2. Tag and push, e.g. `git tag v1.1.0 && git push origin v1.1.0`.
+3. The workflow builds the Windows/macOS installers and publishes a GitHub Release.
+   Final tags (no hyphen) are also published to PyPI; pre-release tags
+   (e.g. `v1.1.0-rc1`) build installers only.
+
+PyPI publishing uses **token-less Trusted Publishing (OIDC)**. One-time setup on
+PyPI: add a trusted publisher for this project with owner `sktelecom`, repository
+`onot`, workflow `release.yml`, and environment `pypi`.
+
 ## License
 
 By contributing, you agree that your contributions are licensed under the

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,17 @@
+onot
+Copyright Kakao Corp. and SK telecom Co., Ltd.
+
+This product is developed by the onot contributors
+(https://github.com/sktelecom/onot).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this software except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SK telecom.
 
 ![onot app](docs/images/04-preview.png)
 
-> Korean user guide / 사용 가이드: [docs/USER_GUIDE.md](docs/USER_GUIDE.md)
+> User guide: [English](docs/USER_GUIDE.en.md) · [한국어](docs/USER_GUIDE.md)
 
 ## Download (desktop app)
 

--- a/docs/USER_GUIDE.en.md
+++ b/docs/USER_GUIDE.en.md
@@ -1,0 +1,85 @@
+# onot User Guide (Windows)
+
+> 한국어 안내는 [USER_GUIDE.md](USER_GUIDE.md)를 참고하세요.
+
+This guide walks you through everything from downloading onot to saving a notice,
+with screenshots. You don't need to install any developer tools — just one installer.
+
+Everything runs on your own PC. Your SBOM file is never sent to any server, and the
+app works without an internet connection.
+
+## 1. Download the installer
+
+Go to the [Releases page](https://github.com/sktelecom/onot/releases). From the
+latest version at the top, download `onot-Setup-x.y.z.exe` (`x.y.z` is the version
+number).
+
+## 2. Install
+
+Double-click the downloaded `onot-Setup-x.y.z.exe` to run it.
+
+Because the installer is not code-signed, Windows SmartScreen may show a
+"Windows protected your PC" or "unknown publisher" warning on first run. Click
+**More info** in the dialog, then the **Run anyway** button that appears, and the
+installation continues. When it finishes, an onot icon is added to the Start menu
+and desktop.
+
+## 3. Launch the app: first screen
+
+When you start onot, the screen below appears. Use the `KO`/`EN` switch in the top
+right to change the interface language. The dashed area on the left is where you drop
+your SBOM file; the right side holds the output settings.
+
+![onot first screen](images/01-home.png)
+
+## 4. Upload an SBOM file
+
+Drag an SBOM file onto the dashed area, or click the area to pick a file from the
+chooser. SPDX (JSON/YAML/Tag-Value/RDF), CycloneDX (JSON/XML), and Excel formats are
+accepted. The format is detected automatically, so you don't need to select it.
+
+Once uploaded, the document name and component count are shown. In the screenshot
+below, `example.spdx.json` was uploaded and 2 components of `EXAMPLE-PRODUCT` were
+recognized.
+
+![After uploading an SBOM file](images/02-uploaded.png)
+
+## 5. Choose output formats and details
+
+On the right, choose the output formats you want (you can select several of html,
+text, markdown, pdf). Set the notice language to Korean or English, and optionally
+enter your organization name, contact email, and source code URL. This information is
+included in the generated notice.
+
+After you pick formats, a download button appears for each one below. In the
+screenshot below, html and markdown were both selected, so two download buttons
+appeared.
+
+![Choosing output formats](images/03-settings.png)
+
+## 6. Preview and download
+
+Click **Generate preview** to view the notice right inside the app. The component
+list, licenses, and copyright information are laid out in a table, and the full
+license texts are included as well.
+
+![Notice preview](images/04-preview.png)
+
+Once you've reviewed it, click the button for the format you want — such as
+**Download html** or **Download markdown** — to save the file. For PDF, a dialog asks
+where to save.
+
+## Frequently asked questions
+
+A SmartScreen warning appears during installation.
+: This happens because the installer is not code-signed. Click **More info**, then
+  **Run anyway** to install.
+
+Can I use it in an environment without internet?
+: Yes. The full license texts are bundled with the app, so it works without a network.
+
+Is my SBOM file sent anywhere?
+: No. Parsing and notice generation all happen on your PC.
+
+Can I use the command line (CLI) or build from source?
+: Yes. See the CLI and developer sections in the [README](../README.md).

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,5 +1,7 @@
 # onot 사용 가이드 (Windows)
 
+> For English, see [USER_GUIDE.en.md](USER_GUIDE.en.md).
+
 처음 오신 분도 따라 할 수 있도록 내려받기부터 고지문 내려받기까지 화면과 함께 설명합니다.
 개발 도구를 설치할 필요는 없습니다. 설치 파일 하나만 받으면 됩니다.
 

--- a/electron/e2e/_helpers.mjs
+++ b/electron/e2e/_helpers.mjs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 // Playwright-electron E2E 공통 헬퍼. testMatch(**/*.e2e.mjs)에 안 걸리므로 테스트로 수집되지 않고 import만 된다.
 import { _electron as electron, expect } from "@playwright/test";
 import http from "node:http";

--- a/electron/e2e/app.e2e.mjs
+++ b/electron/e2e/app.e2e.mjs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 // Playwright-electron E2E: 실제 앱을 기동해 풀 플로우와 사이드카 수명주기를 검증.
 // 플랜 §8.2 시나리오(풀 플로우/사이드카/오프라인/대용량 등)의 핵심 경로. CI(Win/mac)에서 실행.
 import { _electron as electron, expect, test } from "@playwright/test";

--- a/electron/e2e/download.e2e.mjs
+++ b/electron/e2e/download.e2e.mjs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 // 시나리오 1: html/text/markdown 다운로드가 실제 파일시스템까지 도달하는지.
 // 렌더러의 <a download> → Electron will-download → setSavePath로 tmp에 저장한 뒤 내용 단언.
 // (HTTP 응답 바이트 자체는 pytest가 검증하므로, 여기서는 "실제 저장"이라는 통합 경로만 본다.)

--- a/electron/e2e/parse-error.e2e.mjs
+++ b/electron/e2e/parse-error.e2e.mjs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 // 시나리오 3: 잘못된 SBOM 업로드 시 실제 사이드카가 4xx를 반환하고,
 // api.ts detail() → App setError → role="alert"로 이어지는 에러 UX 전체 체인이 동작하는지.
 // (pytest는 400 응답만 검증 — 에러가 UI까지 표면화되는지는 통합에서만.)

--- a/electron/e2e/pdf-export.e2e.mjs
+++ b/electron/e2e/pdf-export.e2e.mjs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 // 시나리오 2: PDF는 사이드카(weasyprint)가 아니라 Electron printToPDF 경로로 생성된다.
 // Download pdf → window.onot.exportPdf → ipcMain "export-pdf" → offscreen printToPDF → dialog → fs.writeFile.
 // dialog.showSaveDialog를 런타임 stub해 저장 경로를 주입한다(프로덕션 무수정).

--- a/electron/e2e/sidecar-lifecycle.e2e.mjs
+++ b/electron/e2e/sidecar-lifecycle.e2e.mjs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 // 시나리오 4: 앱 종료 시 사이드카가 동반 종료되어 고아 프로세스가 남지 않는지.
 // main의 sidecar pid는 외부로 노출되지 않으므로, apiBase 포트의 healthz로 검증한다.
 // 기동 후 200 → app.close() → 같은 포트가 연결 거부될 때까지(=프로세스 종료) 폴링.

--- a/electron/lib/sidecar.mjs
+++ b/electron/lib/sidecar.mjs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 // Python FastAPI 사이드카 수명주기 관리(순수 Node — electron 비의존, 단위 테스트 가능).
 import { spawn } from "node:child_process";
 import http from "node:http";

--- a/electron/scripts/capture-screenshots.mjs
+++ b/electron/scripts/capture-screenshots.mjs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 // 사용자 가이드용 앱 화면 캡처 스크립트(일회성 문서 생성 도구).
 // 실제 Electron 데스크톱 앱을 띄워 한국어 UI로 업로드→파싱→미리보기 흐름을 캡처한다.
 // 실행: pnpm -C electron exec node scripts/capture-screenshots.mjs

--- a/electron/test/sidecar.test.mjs
+++ b/electron/test/sidecar.test.mjs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 // 사이드카 수명주기 테스트(S4 회귀): spawn→health→stop→고아 없음.
 // 실제 venv 사이드카(python -m onot.api.serve)를 띄워 검증한다(electron 불필요).
 import assert from "node:assert/strict";

--- a/frontend/src/components/FileDropzone.test.tsx
+++ b/frontend/src/components/FileDropzone.test.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { FileDropzone } from "./FileDropzone";

--- a/frontend/src/components/FileDropzone.tsx
+++ b/frontend/src/components/FileDropzone.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { UploadCloud } from "lucide-react";
 import { useCallback, useState } from "react";
 import { cn } from "../lib/cn";

--- a/frontend/src/components/Preview.tsx
+++ b/frontend/src/components/Preview.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 export function Preview({ html, title }: { html: string; title: string }) {
   // iframe srcdoc + sandbox로 미리보기를 격리(CSS 충돌/스크립트 차단)
   return (

--- a/frontend/src/components/SettingsPanel.test.tsx
+++ b/frontend/src/components/SettingsPanel.test.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { type NoticeSettings, SettingsPanel } from "./SettingsPanel";

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { CompanyConfig } from "../lib/api";
 import { t, type UiLang } from "../lib/i18n";
 import { Card, CardTitle } from "./ui/Card";

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { ButtonHTMLAttributes } from "react";
 import { cn } from "../../lib/cn";
 

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { HTMLAttributes } from "react";
 import { cn } from "../../lib/cn";
 

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchFormats, parseSbom, renderNotice, resolveApiBase } from "./api";
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 // onot FastAPI 사이드카 클라이언트. 베이스 URL 우선순위:
 // URL 쿼리(?apiBase=, Electron이 동적 포트 주입) > 빌드 환경변수 > 동일 출처("").
 export function resolveApiBase(): string {

--- a/frontend/src/lib/cn.test.ts
+++ b/frontend/src/lib/cn.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, expect, it } from "vitest";
 import { cn } from "./cn";
 

--- a/frontend/src/lib/cn.ts
+++ b/frontend/src/lib/cn.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 

--- a/frontend/src/lib/i18n.test.ts
+++ b/frontend/src/lib/i18n.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, expect, it } from "vitest";
 import { messages, t } from "./i18n";
 

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 // UI 라벨 다국어. 백엔드 고지문 i18n과 별개(여기는 앱 화면 문구).
 export type UiLang = "en" | "ko";
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,4 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import "@testing-library/jest-dom/vitest";

--- a/src/onot/__init__.py
+++ b/src/onot/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """onot — open source software notice generator from SBOM/SPDX documents."""
 
 __version__ = "1.1.0.dev0"

--- a/src/onot/api/__init__.py
+++ b/src/onot/api/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """FastAPI 사이드카 (Electron 데스크톱 + 향후 정적 SaaS 백엔드 공용)."""
 
 from onot.api.app import create_app

--- a/src/onot/api/app.py
+++ b/src/onot/api/app.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """FastAPI 앱 팩토리."""
 
 from __future__ import annotations

--- a/src/onot/api/routes.py
+++ b/src/onot/api/routes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """API 라우트: healthz, formats, parse, render.
 
 업로드는 메모리에서 임시파일로 받아 처리 후 폐기(stateless). 경로는 사용자 입력에서

--- a/src/onot/api/serve.py
+++ b/src/onot/api/serve.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """사이드카 서버 진입점. FastAPI 앱을 127.0.0.1:PORT에 띄운다(Electron이 spawn).
 
 uvicorn에 import string이 아니라 앱 인스턴스를 직접 넘겨 frozen(PyInstaller) 환경에서도

--- a/src/onot/cli/__init__.py
+++ b/src/onot/cli/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """onot CLI (Typer)."""

--- a/src/onot/cli/main.py
+++ b/src/onot/cli/main.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """onot CLI 진입점 (Typer).
 
 generate(다중 포맷·자동감지·언어·설정), formats, version.

--- a/src/onot/core/__init__.py
+++ b/src/onot/core/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """설정·파일명·출력 쓰기 등 코어 유틸."""

--- a/src/onot/core/config.py
+++ b/src/onot/core/config.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """설정. 회사 정보·언어·테마·오프라인 모드. 우선순위: CLI/명시 인자 > yaml > 환경변수 > 기본값.
 
 환경변수 예: ONOT_DEFAULT_LANG=ko, ONOT_COMPANY__ORGANIZATION="SK telecom".

--- a/src/onot/core/naming.py
+++ b/src/onot/core/naming.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """출력 파일명 규칙. (HTML 앵커 슬러그는 M4 license_links에서 추가)"""
 
 from __future__ import annotations

--- a/src/onot/core/writer.py
+++ b/src/onot/core/writer.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """산출물 디스크 쓰기(render와 분리)."""
 
 from __future__ import annotations

--- a/src/onot/domain/__init__.py
+++ b/src/onot/domain/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """onot 도메인 모델 (순수 Pydantic, 외부 의존 없음)."""
 
 from onot.domain.errors import (

--- a/src/onot/domain/errors.py
+++ b/src/onot/domain/errors.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """onot 예외 계층. 사용자향 실패는 모두 OnotError 하위로 모은다."""
 
 from __future__ import annotations

--- a/src/onot/domain/models.py
+++ b/src/onot/domain/models.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """onot 도메인 모델 (순수 Pydantic v2, 외부 파서/네트워크 의존 없음).
 
 모든 모델은 frozen=True, extra="forbid". 라이선스 표현식과 저작권은 값 객체로 구조화해

--- a/src/onot/ingest/__init__.py
+++ b/src/onot/ingest/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """입력 어댑터: 외부 포맷 → onot.domain.NoticeDocument."""
 
 from onot.ingest.base import IngestAdapter, IngestResult

--- a/src/onot/ingest/_mapping.py
+++ b/src/onot/ingest/_mapping.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """spdx-tools Document → onot.domain 매핑 헬퍼."""
 
 from __future__ import annotations

--- a/src/onot/ingest/_xml_guard.py
+++ b/src/onot/ingest/_xml_guard.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """신뢰할 수 없는 XML 입력의 XXE·확장 폭탄(billion-laughs) 방어.
 
 라이브러리 내부 파서에 의존하지 않고, 파싱 전에 DOCTYPE/ENTITY 선언을 거부한다.

--- a/src/onot/ingest/base.py
+++ b/src/onot/ingest/base.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """입력 어댑터 공통 인터페이스."""
 
 from __future__ import annotations

--- a/src/onot/ingest/cyclonedx.py
+++ b/src/onot/ingest/cyclonedx.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """CycloneDxAdapter — cyclonedx-python-lib로 CycloneDX(JSON/XML) 파싱.
 
 CDX는 concluded/declared 구분이 없어 라이선스를 license_declared로 매핑한다(effective가

--- a/src/onot/ingest/detect.py
+++ b/src/onot/ingest/detect.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """포맷 자동 감지(확장자 힌트 + 내용 스니핑)."""
 
 from __future__ import annotations

--- a/src/onot/ingest/excel.py
+++ b/src/onot/ingest/excel.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """ExcelAdapter — 1.x onot/SPDX 스프레드시트 템플릿 → NoticeDocument.
 
 Document Info, Package Info, Extracted License Info 시트를 읽어 NoticeDocument로 매핑한다.

--- a/src/onot/ingest/registry.py
+++ b/src/onot/ingest/registry.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """포맷 어댑터 레지스트리 + load_document 진입점."""
 
 from __future__ import annotations

--- a/src/onot/ingest/spdx.py
+++ b/src/onot/ingest/spdx.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """SpdxAdapter — spdx-tools로 SPDX 2.x(JSON/YAML/Tag-Value/RDF) 파싱.
 
 SPDX 3.0 입력은 후속(D-005). RDF/XML은 파싱 전 XXE 가드를 적용한다.

--- a/src/onot/license/__init__.py
+++ b/src/onot/license/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """라이선스 해석 레이어.
 
 기본 `resolve()`는 번들 카탈로그 기반 오프라인 해석(에어갭, 결정적)이다. 온라인 보충이

--- a/src/onot/license/cache.py
+++ b/src/onot/license/cache.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """라이선스 전문 디스크 캐시(platformdirs). 네임스페이스에 라이선스 리스트 버전 포함."""
 
 from __future__ import annotations

--- a/src/onot/license/catalog.py
+++ b/src/onot/license/catalog.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """번들된 SPDX license-list-data 카탈로그(전문 포함, 에어갭 완결).
 
 데이터는 `scripts/update_license_data.py`로 vendoring한다. frozen 환경 안전을 위해

--- a/src/onot/license/expression_parser.py
+++ b/src/onot/license/expression_parser.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """SPDX 라이선스 표현식 파싱(license-expression 래퍼).
 
 중첩 OR/AND/WITH와 + 연산자를 평탄화해 심볼을 추출한다. 파싱 실패는

--- a/src/onot/license/fetcher.py
+++ b/src/onot/license/fetcher.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """원격 라이선스 전문 조회(httpx + 지수 백오프 재시도 + 프록시 존중).
 
 번들에 없는 신규/희귀 라이선스를 온라인에서 보충하는 보조 경로. 에어갭/오프라인에서는

--- a/src/onot/license/resolver.py
+++ b/src/onot/license/resolver.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """LicenseResolver — 표현식 해석 + 전문 조회를 오케스트레이션.
 
 각 패키지의 effective_expression을 평탄화해 라이선스 목록과 역참조(used_by)를 만들고,

--- a/src/onot/rendering/__init__.py
+++ b/src/onot/rendering/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """고지문 산출물 렌더링."""
 
 from __future__ import annotations

--- a/src/onot/rendering/base.py
+++ b/src/onot/rendering/base.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """Renderer ABC + 공유 Jinja 환경.
 
 render()는 파일 I/O 없는 순수 함수다. 디스크 쓰기는 core.writer.OutputWriter가 담당한다.

--- a/src/onot/rendering/context.py
+++ b/src/onot/rendering/context.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """렌더 컨텍스트 구성. 회사 설정과 SBOM 값을 병합한다(회사 설정 우선, 비면 SBOM)."""
 
 from __future__ import annotations

--- a/src/onot/rendering/filters.py
+++ b/src/onot/rendering/filters.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """Jinja 커스텀 필터: 앵커 슬러그, 라이선스 표현식의 토큰 링크화."""
 
 from __future__ import annotations

--- a/src/onot/rendering/html.py
+++ b/src/onot/rendering/html.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """HtmlRenderer — self-contained HTML(테마 CSS 인라인, autoescape, 라이선스 앵커)."""
 
 from __future__ import annotations

--- a/src/onot/rendering/i18n.py
+++ b/src/onot/rendering/i18n.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """메시지 카탈로그 기반 다국어. 누락 키는 키 자체를 반환(테스트로 정합성 검증)."""
 
 from __future__ import annotations

--- a/src/onot/rendering/markdown.py
+++ b/src/onot/rendering/markdown.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """MarkdownRenderer — GitHub 호환 Markdown 고지문."""
 
 from __future__ import annotations

--- a/src/onot/rendering/pdf.py
+++ b/src/onot/rendering/pdf.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """PdfRenderer — HTML을 PDF로 변환(WeasyPrint, onot[pdf] extras).
 
 설치형 데스크톱은 Electron printToPDF를 쓰고, CLI 등 헤드리스 경로에서 이 렌더러를 쓴다.

--- a/src/onot/rendering/registry.py
+++ b/src/onot/rendering/registry.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """출력 포맷 → Renderer 매핑."""
 
 from __future__ import annotations

--- a/src/onot/rendering/text.py
+++ b/src/onot/rendering/text.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """TextRenderer — 플레인 텍스트 고지문."""
 
 from __future__ import annotations

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import pytest

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """API 계약: healthz, formats, parse, render(포맷·언어·다운로드·회사)."""
 
 from __future__ import annotations

--- a/tests/api/test_security.py
+++ b/tests/api/test_security.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """API 보안/입력 검증: XXE 업로드, 미지원/빈/대용량, 파일명 traversal."""
 
 from __future__ import annotations

--- a/tests/api/test_serve.py
+++ b/tests/api/test_serve.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """사이드카 진입점: uvicorn에 올바른 host/port로 위임하는지(실제 서버는 안 띄움)."""
 
 from __future__ import annotations

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """CLI: 다중 포맷, 자동감지, 언어, stdout, formats/version, 오류 종료 코드."""
 
 from __future__ import annotations

--- a/tests/core/test_writer.py
+++ b/tests/core/test_writer.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """OutputWriter: 텍스트/바이너리 쓰기, 상위 디렉터리 생성."""
 
 from __future__ import annotations

--- a/tests/e2e/test_slice.py
+++ b/tests/e2e/test_slice.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """M0.5 수직 슬라이스 end-to-end 테스트: Excel → domain → license → HTML → CLI."""
 
 from __future__ import annotations

--- a/tests/ingest/test_cyclonedx.py
+++ b/tests/ingest/test_cyclonedx.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """CycloneDxAdapter: JSON/XML, id/expression/named 라이선스, purl, copyright, 오류."""
 
 from __future__ import annotations

--- a/tests/ingest/test_detect.py
+++ b/tests/ingest/test_detect.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """포맷 자동 감지: 확장자+내용 스니핑, .json 모호성 해소, 미지원 거부."""
 
 from __future__ import annotations

--- a/tests/ingest/test_equivalence.py
+++ b/tests/ingest/test_equivalence.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """크로스포맷 등가성(R-ING-3): 같은 패키지를 SPDX/CycloneDX로 표현 시 동일 매핑."""
 
 from __future__ import annotations

--- a/tests/ingest/test_excel_robust.py
+++ b/tests/ingest/test_excel_robust.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """ExcelAdapter 견고성 — 짧은 행/빈 행/시트 누락에서 IndexError 없이 동작(L3 #1 회귀)."""
 
 from __future__ import annotations

--- a/tests/ingest/test_registry.py
+++ b/tests/ingest/test_registry.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """레지스트리: 어댑터 목록, load_document end-to-end."""
 
 from __future__ import annotations

--- a/tests/ingest/test_spdx.py
+++ b/tests/ingest/test_spdx.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """SpdxAdapter: 패키지 매핑, NOASSERTION 처리, organization/email, extracted license, 오류."""
 
 from __future__ import annotations

--- a/tests/ingest/test_xml_security.py
+++ b/tests/ingest/test_xml_security.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """XML 입력 보안(R-ING-2): XXE·확장 폭탄 거부."""
 
 from __future__ import annotations

--- a/tests/license/test_cache.py
+++ b/tests/license/test_cache.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """디스크 캐시(R-LIC-3): hit/miss, 손상 내성."""
 
 from __future__ import annotations

--- a/tests/license/test_catalog.py
+++ b/tests/license/test_catalog.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """번들 SPDX 카탈로그(R-LIC-2 일부): 전문 포함, 라이선스/예외 조회."""
 
 from __future__ import annotations

--- a/tests/license/test_expression.py
+++ b/tests/license/test_expression.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """라이선스 표현식 해석 매트릭스(R-LIC-1): 중첩/+/WITH/대소문자/unknown."""
 
 from __future__ import annotations

--- a/tests/license/test_fetcher.py
+++ b/tests/license/test_fetcher.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """원격 fetcher: 성공/예외필드/404/재시도(respx mock, 네트워크 없음)."""
 
 from __future__ import annotations

--- a/tests/license/test_resolve.py
+++ b/tests/license/test_resolve.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """license resolver 결정성 테스트(R-DOM-2/R-LIC)."""
 
 from __future__ import annotations

--- a/tests/license/test_resolver.py
+++ b/tests/license/test_resolver.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """LicenseResolver: 에어갭 전문 채움, 동봉 ref, unknown, 캐시, 원격 fetch."""
 
 from __future__ import annotations

--- a/tests/rendering/test_context.py
+++ b/tests/rendering/test_context.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """컨텍스트 병합: 회사 설정 우선, SBOM 폴백, 연도 추론, 생성일 주입."""
 
 from __future__ import annotations

--- a/tests/rendering/test_escape.py
+++ b/tests/rendering/test_escape.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """HTML 이스케이프 회귀(§8.1): 사용자 입력이 출력에 그대로 들어가지 않는다."""
 
 from __future__ import annotations

--- a/tests/rendering/test_filters.py
+++ b/tests/rendering/test_filters.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """Jinja 필터: anchor 슬러그, license_links 토큰 링크화 + 이스케이프."""
 
 from __future__ import annotations

--- a/tests/rendering/test_golden.py
+++ b/tests/rendering/test_golden.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """포맷별 골든 + 결정성(2회 렌더 동일)."""
 
 from __future__ import annotations

--- a/tests/rendering/test_i18n.py
+++ b/tests/rendering/test_i18n.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """i18n 정합성: ko/en 키·플레이스홀더 동일, 누락 키 처리, 폴백."""
 
 from __future__ import annotations

--- a/tests/rendering/test_renderers.py
+++ b/tests/rendering/test_renderers.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """렌더러 4종: 포맷별 산출, 메타데이터, 미지원 포맷, PDF(있으면)."""
 
 from __future__ import annotations

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """예외 계층 테스트."""
 
 from __future__ import annotations

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
 """M1 도메인 모델 단위 테스트: 검증 규칙, 값 객체, 중복 제거, 결정성."""
 
 from __future__ import annotations


### PR DESCRIPTION
검토에서 의도적으로 남겨뒀던 후속 3건을 순차 반영한다.

## 1. PyPI 게시 자동화 (`ci`)
- `release.yml`에 `publish-pypi` 잡 추가 — 최종 릴리스 태그(하이픈 없는 `v1.2.3`)에서 sdist/wheel을 빌드해 **토큰 없는 Trusted Publishing(OIDC)** 으로 PyPI 게시. rc/beta 태그는 데스크톱 설치파일만.
- 태그 버전을 pyproject에 주입해 `.dev0` 대신 태그를 단일 진실로 사용.
- 잡별 최소 권한 분리(`publish-desktop: contents:write`, `publish-pypi: id-token:write`).
- `CONTRIBUTING.md`에 릴리스 절차 + PyPI 신뢰 게시자 최초 설정 안내.
- **메인테이너 1회 설정 필요**: PyPI에서 trusted publisher 등록(owner `sktelecom`, repo `onot`, workflow `release.yml`, environment `pypi`).

## 2. 영어 사용자 가이드 (`docs`)
- `docs/USER_GUIDE.en.md` 추가(한글판과 동일 구조·스크린샷), 한↔영 상호 링크, README에서 두 언어 연결.

## 3. SPDX 헤더 + NOTICE (`chore`)
- `NOTICE`(Apache-2.0) 추가.
- 1차 소스 90개(`src`·`tests` py, `frontend/src` ts/tsx, `electron` mjs)에 `SPDX-FileCopyrightText` + `SPDX-License-Identifier: Apache-2.0` 헤더 추가(REUSE). 오픈소스 고지 도구답게 자기 코드도 기계 판독 가능한 표기를 갖춤.

## 검증
- `release.yml` actionlint 통과
- 로컬 게이트 통과(ruff + pytest cov≥90 + frontend build/test + electron 테스트) — 헤더가 빌드/린트/테스트에 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)