### PR TITLE
release(1.1.0): 버전 확정 dev0 → 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-03
+
 This release is a full rewrite of onot as a type-safe Python core with a React UI,
 shipped as an installable desktop app. It is the successor to the 1.0.0 PyQt-based
 generator.
@@ -37,5 +39,6 @@ generator.
 - Initial public release: PyQt-based desktop generator that produced OSS notices
   from SPDX documents.
 
-[Unreleased]: https://github.com/sktelecom/onot/compare/1.0.0...HEAD
+[Unreleased]: https://github.com/sktelecom/onot/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/sktelecom/onot/compare/1.0.0...v1.1.0
 [1.0.0]: https://github.com/sktelecom/onot/releases/tag/1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "onot"
-version = "1.1.0.dev0"
+version = "1.1.0"
 description = "Generate open source software notices from SBOM/SPDX documents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/onot/__init__.py
+++ b/src/onot/__init__.py
@@ -3,4 +3,4 @@
 
 """onot — open source software notice generator from SBOM/SPDX documents."""
 
-__version__ = "1.1.0.dev0"
+__version__ = "1.1.0"


### PR DESCRIPTION
v1.1.0 릴리스 태그 푸시 전 버전을 확정한다.

- `pyproject.toml`, `src/onot/__init__.py`: `1.1.0.dev0` → `1.1.0`
- `CHANGELOG.md`: `[Unreleased]` → `[1.1.0] - 2026-06-03`, 비교 링크 정리
- `frontend`/`electron` package.json은 이미 `1.1.0`

머지 후 `v1.1.0` 태그를 푸시하면 release 워크플로가 Windows/macOS 설치파일을 빌드해 GitHub Release를 게시한다.

> ⚠️ PyPI 게시(`publish-pypi`)는 PyPI 신뢰 게시자(Trusted Publisher) 최초 설정이 끝나야 성공한다. 미설정 시 해당 잡만 실패하고 데스크톱 릴리스에는 영향이 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)