### PR TITLE
chore(1.1): 공개 OSS 마감 — PyPI 안내·제3자 고지·mypy·py.typed·릴리스 SBOM

### DIFF
--- a/.claude/gate.sh
+++ b/.claude/gate.sh
@@ -19,6 +19,9 @@ ruff check src tests
 echo "==> ruff format --check"
 ruff format --check src tests
 
+echo "==> mypy"
+mypy
+
 echo "==> pytest (cov-fail-under=${COV_MIN})"
 pytest --cov --cov-report=term-missing --cov-fail-under="${COV_MIN}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,16 @@ jobs:
       - run: ruff check src tests
       - run: ruff format --check src tests
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[spdx,cyclonedx,excel,api,pdf,dev]"
+      - run: mypy
+
   test-core:
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,3 +85,22 @@ jobs:
           python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-sbom:
+    name: Attach SBOM to release
+    needs: publish-desktop # 릴리스가 생성된 뒤 자산을 첨부한다
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # 릴리스에 자산 업로드
+    steps:
+      - uses: actions/checkout@v6
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: onot-${{ github.ref_name }}-sbom.cdx.json
+      - name: Attach SBOM to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.ref_name }}" "onot-${{ github.ref_name }}-sbom.cdx.json" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
           format: cyclonedx-json
           output-file: onot-${{ github.ref_name }}-sbom.cdx.json
       - name: Attach SBOM to the release
+        # github.ref_name을 셸에 직접 보간하지 않고 기본 제공 env로 받아 인젝션을 피한다.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.ref_name }}" "onot-${{ github.ref_name }}-sbom.cdx.json" --clobber
+        run: gh release upload "$GITHUB_REF_NAME" "onot-${GITHUB_REF_NAME}-sbom.cdx.json" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ electron/playwright-report/
 spikes/**/out/
 
 
+
+# 타입/린트 캐시
+.mypy_cache/
+.ruff_cache/

--- a/NOTICE
+++ b/NOTICE
@@ -15,3 +15,14 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+-------------------------------------------------------------------------------
+
+Third-party data bundled with this product:
+
+SPDX License List data (https://github.com/spdx/license-list-data),
+vendored in src/onot/license/data/ to enable offline license-text lookup.
+The SPDX License List, including the license texts, is published by the
+SPDX Workgroup, a Linux Foundation project, and is made available under the
+Creative Commons Zero v1.0 Universal (CC0-1.0) public domain dedication.
+See https://spdx.org/licenses/ for the source and version.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and choose **Open** to pass Gatekeeper.
 ## CLI
 
 ```bash
-pip install -e ".[spdx,cyclonedx,excel,api]"
+pip install "onot[spdx,cyclonedx,excel,api]"   # from PyPI; add ,pdf for PDF output
 
 # SBOM (format auto-detected) → notices in multiple formats
 onot generate -i sbom.spdx.json -f html -f markdown --output-dir ./output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
 ]
 dependencies = [
     "pydantic[email]>=2.13.4",
@@ -62,6 +63,7 @@ dev = [
     "pytest-cov>=7.1.0",
     "ruff>=0.8",
     "respx>=0.21",
+    "mypy>=1.13",
 ]
 all = [
     "onot[spdx,cyclonedx,excel,api]",
@@ -82,7 +84,7 @@ where = ["src"]
 include = ["onot*"]
 
 [tool.setuptools.package-data]
-onot = ["license/data/**/*", "rendering/templates/**/*", "rendering/themes/**/*", "rendering/i18n/*"]
+onot = ["py.typed", "license/data/**/*", "rendering/templates/**/*", "rendering/themes/**/*", "rendering/i18n/*"]
 
 [tool.ruff]
 line-length = 100
@@ -102,6 +104,13 @@ ignore = ["E501"]  # line length handled by formatter
 testpaths = ["tests"]
 pythonpath = ["src"]
 addopts = "-q"
+
+[tool.mypy]
+files = ["src/onot"]
+python_version = "3.11"
+# 다수의 의존성(spdx-tools/weasyprint/license-expression 등)이 타입 스텁을 제공하지
+# 않으므로, onot 자체 코드의 타입 정합성에 집중한다.
+ignore_missing_imports = true
 
 [tool.coverage.run]
 source = ["onot"]

--- a/src/onot/api/routes.py
+++ b/src/onot/api/routes.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import tempfile
 from datetime import datetime
 from pathlib import Path
+from typing import Literal, cast
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import Response
@@ -110,7 +111,7 @@ async def render_notice(
 
     data, suffix = await _read_upload(file)
     settings = Settings(
-        default_lang=lang,
+        default_lang=cast(Literal["ko", "en"], lang),
         company=CompanyConfig(
             organization=organization,
             contact_email=contact_email,

--- a/src/onot/ingest/_mapping.py
+++ b/src/onot/ingest/_mapping.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from spdx_tools.spdx.model import ActorType
 
 from onot.domain.models import (
@@ -45,7 +47,7 @@ def _purl(package: object) -> str | None:
     return None
 
 
-def _package(package: object) -> Package:
+def _package(package: Any) -> Package:
     return Package(
         name=package.name,
         version=_text(getattr(package, "version", None)),
@@ -59,7 +61,7 @@ def _package(package: object) -> Package:
     )
 
 
-def spdx_document_to_notice(document: object) -> NoticeDocument:
+def spdx_document_to_notice(document: Any) -> NoticeDocument:
     creation_info = document.creation_info
     organization, email = _organization(creation_info)
     creation = CreationInfo(

--- a/src/onot/ingest/base.py
+++ b/src/onot/ingest/base.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import ClassVar, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict
 
@@ -22,7 +22,7 @@ class IngestResult(BaseModel):
 
 @runtime_checkable
 class IngestAdapter(Protocol):
-    format_id: ClassVar[str]
+    format_id: str
 
     def sniff(self, path: Path, head: bytes) -> float:
         """이 어댑터가 입력을 처리할 신뢰도(0.0~1.0)."""

--- a/src/onot/ingest/cyclonedx.py
+++ b/src/onot/ingest/cyclonedx.py
@@ -46,7 +46,7 @@ class CycloneDxAdapter:
     def _parse_json(data: bytes):
         from cyclonedx.model.bom import Bom
 
-        return Bom.from_json(json.loads(data))
+        return Bom.from_json(json.loads(data))  # type: ignore[attr-defined]  # py-serializable 동적 주입
 
     @staticmethod
     def _parse_xml(data: bytes):
@@ -59,7 +59,7 @@ class CycloneDxAdapter:
             element = fromstring(data)
         except DefusedXmlException as exc:  # 인코딩 우회 등 2차 방어
             raise IngestValidationError(["unsafe XML rejected (XXE protection)"]) from exc
-        return Bom.from_xml(element)
+        return Bom.from_xml(element)  # type: ignore[attr-defined]  # py-serializable 동적 주입
 
 
 def _register_named_ref(name: str, text: str, refs: dict[str, LicenseRef]) -> str:


### PR DESCRIPTION
공개 전 검토(2차)에서 합의한 **P1 전체 + P2**를 반영한다. (P1의 GitHub 보안 기능 활성화·main 브랜치 보호는 저장소 설정으로 별도 적용 예정.)

## P1
- **README**: 설치 안내를 PyPI로 갱신 — `pip install "onot[spdx,cyclonedx,excel,api]"`
- **NOTICE**: 번들 **SPDX license-list-data**(spdx.org, CC0-1.0) 출처·라이선스 고지. OSS 고지 도구가 자기 번들 데이터를 고지하도록 정정.

## P2
- **mypy 도입**: `[tool.mypy]` + dev 의존성 + CI `typecheck` 잡 + `gate.sh`. 외부 스텁 부재는 `ignore_missing_imports`로 처리. 자체 코드 타입 오류 4건 수정:
  - `_mapping.py`: spdx-tools 객체 `object`→`Any`
  - `base.py`: `IngestAdapter.format_id` `ClassVar[str]`→`str`(어댑터 클래스 속성과 정합)
  - `cyclonedx.py`: py-serializable 동적 주입 메서드에 타깃 `type: ignore[attr-defined]`
  - `routes.py`: `lang`을 `Literal["ko","en"]`로 narrowing
- **py.typed** 마커 + `Typing :: Typed` classifier — 다운스트림에 타입 정보 제공
- **release.yml**: CycloneDX SBOM 생성→릴리스 자산 첨부(도그푸딩)
- `.gitignore`: `.mypy_cache/`, `.ruff_cache/`

## 검증
- 로컬 게이트 통과: ruff + **mypy(0 errors/39 files)** + pytest(cov≥90) + frontend + electron
- `python -m build` sdist에 `py.typed` 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)