### PR TITLE
chore(1.1): P3 정비 — OpenSSF Scorecard·CITATION·GOVERNANCE·attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,8 @@ jobs:
           python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true # PEP 740 provenance 첨부
 
   publish-sbom:
     name: Attach SBOM to release

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,40 @@
+name: scorecard
+
+# OpenSSF Scorecard — 공급망 보안 모범사례 점수를 측정해 코드 스캐닝(Security 탭)과
+# 공개 배지(api.securityscorecards.dev)로 노출한다.
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 3 * * 1" # 매주 월요일 03:00 UTC
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # SARIF를 코드 스캐닝에 업로드
+      id-token: write # 공개 배지용 결과 게시(OIDC)
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+message: "If you use onot in your work, please cite it using these metadata."
+title: "onot"
+abstract: >-
+  A tool that generates open source software notices (OSS Notice) from SBOM
+  documents (SPDX, CycloneDX, Excel), producing HTML, Text, Markdown, and PDF.
+type: software
+authors:
+  - given-names: Hyunmin
+    family-names: Han
+    affiliation: Kakao
+  - given-names: Haksung
+    family-names: Jang
+    affiliation: SK telecom
+repository-code: "https://github.com/sktelecom/onot"
+url: "https://github.com/sktelecom/onot"
+license: Apache-2.0
+keywords:
+  - sbom
+  - spdx
+  - cyclonedx
+  - oss-compliance
+  - license-compliance

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,61 @@
+# Governance
+
+onot is an open source project jointly developed and maintained by **Kakao** and
+**SK telecom**. This document describes how decisions are made and how the project is
+run. It is intentionally lightweight and will evolve with the community.
+
+## Roles
+
+### Users
+
+Anyone who uses onot. Users are encouraged to open issues, ask questions in
+[Discussions](https://github.com/sktelecom/onot/discussions), and propose changes.
+
+### Contributors
+
+Anyone who contributes code, documentation, tests, or reviews. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for how to get started. There is no formal process
+to become a contributor — opening a pull request is enough.
+
+### Maintainers
+
+Maintainers are responsible for reviewing and merging changes, triaging issues, and
+shepherding releases. They are listed in [CODEOWNERS](.github/CODEOWNERS) and in the
+README. The current maintainers are nominated by Kakao and SK telecom.
+
+Maintainers are expected to:
+
+- Review pull requests in their areas and uphold the quality gate (CI, tests,
+  coverage, security checks).
+- Act in the project's interest and follow the
+  [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Decision making
+
+Most decisions are made by **lazy consensus**: a proposal (issue or pull request) that
+receives no sustained objection within a reasonable period is considered accepted.
+
+- **Code changes** require approval from at least one maintainer who is not the author,
+  and all required CI checks must pass before merging (enforced by branch protection).
+- **Significant changes** (architecture, public API, breaking changes, new
+  dependencies, release policy) should be discussed in an issue first and require
+  agreement between the Kakao and SK telecom maintainers.
+- If consensus cannot be reached, the maintainers from both organizations decide
+  together; ties are resolved by discussion rather than a casting vote.
+
+## Becoming a maintainer
+
+Contributors who have a sustained track record of high-quality contributions and
+reviews may be invited to become maintainers by the existing maintainers, with
+agreement from both organizations.
+
+## Releases
+
+Releases are tag-driven and automated; see the "Releasing" section of
+[CONTRIBUTING.md](CONTRIBUTING.md). Any maintainer may cut a release once `main` is
+green and the version and changelog are prepared.
+
+## Changing this document
+
+Changes to governance follow the same pull request process and require agreement
+between the Kakao and SK telecom maintainers.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![CI](https://github.com/sktelecom/onot/actions/workflows/ci.yml/badge.svg)](https://github.com/sktelecom/onot/actions/workflows/ci.yml)
 [![Security](https://github.com/sktelecom/onot/actions/workflows/security.yml/badge.svg)](https://github.com/sktelecom/onot/actions/workflows/security.yml)
 [![License](https://img.shields.io/github/license/sktelecom/onot)](LICENSE)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/sktelecom/onot/badge)](https://scorecard.dev/viewer/?uri=github.com/sktelecom/onot)
+[![PyPI](https://img.shields.io/pypi/v/onot)](https://pypi.org/project/onot/)
 [![Latest release](https://img.shields.io/github/v/release/sktelecom/onot?sort=semver)](https://github.com/sktelecom/onot/releases/latest)
 [![Download for Windows](https://img.shields.io/badge/Download-Windows%20installer-0078D6?logo=windows&logoColor=white)](https://github.com/sktelecom/onot/releases/latest)
 [![Downloads](https://img.shields.io/github/downloads/sktelecom/onot/total)](https://github.com/sktelecom/onot/releases)


### PR DESCRIPTION
공개 OSS 완성도를 위한 선택 항목(P3)을 반영한다.

## 추가
- **OpenSSF Scorecard** (`.github/workflows/scorecard.yml`): 주간 + main push로 공급망 보안 점수 측정 → 코드 스캐닝 업로드 + 공개 배지
- **CITATION.cff**: 기계 판독 인용 메타데이터
- **GOVERNANCE.md**: Kakao·SK telecom 공동 운영 의사결정 구조(역할·합의·릴리스)
- **release.yml**: PyPI publish `attestations: true`(PEP 740 provenance — 다음 릴리스부터 적용)
- **README**: OpenSSF Scorecard·PyPI 버전 배지

## 저장소 설정(별도 적용)
- GitHub **Discussions** 활성화 완료

## 제외(사유 명시)
- `FUNDING.yml` — 기업 주도 프로젝트라 불요
- 설치파일 **코드 서명**(D-016) — 유료 인증서/시크릿 필요, 조직만 가능
- GitHub 라이선스 인식 — 재확인 결과 정상(`apache-2.0`), 이전 null은 API 지연

🤖 Generated with [Claude Code](https://claude.com/claude-code)