### PR TITLE
ci(1.1): scorecard-action v2.4.3 핀

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
scorecard 워크플로가 `ossf/scorecard-action@v2`(부동 태그 없음)로 실패 → `v2.4.3`로 고정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)