### PR TITLE
chore: gitignore electron-builder output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ node_modules/
 electron/test-results/
 electron/playwright-report/
 
+# electron-builder output (local installer builds)
+electron/dist-electron/
+
 # onot 2.0 spike outputs
 spikes/**/out/
 


### PR DESCRIPTION
Ignore `electron/dist-electron/` (local electron-builder installer output) so build artifacts are never accidentally committed. Surfaced while preparing the 1.1.1 release.