### PR TITLE
fix: QA report findings O-1..O-4 (parse robustness, UX, packaged-render guard)

### DIFF
--- a/electron/e2e/file-load.e2e.mjs
+++ b/electron/e2e/file-load.e2e.mjs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Guards the packaged file:// render path (issue #68 / QA O-4). The other E2E specs load the
+// frontend over http:// (dev server), where absolute asset paths happen to work, so they cannot
+// catch a blank screen caused by file:// asset resolution. This launches the app in production
+// loadFile mode against the built frontend/dist and asserts the UI actually mounts.
+import { _electron as electron, expect, test } from "@playwright/test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const electronRoot = path.resolve(here, "..");
+const frontendDist = path.resolve(here, "..", "..", "frontend", "dist");
+
+test("packaged file:// load renders the UI (no blank screen)", async () => {
+  const consoleErrors = [];
+  const app = await electron.launch({
+    args: [electronRoot],
+    cwd: electronRoot,
+    env: { ...process.env, ONOT_FRONTEND_DIR: frontendDist },
+  });
+  const window = await app.firstWindow();
+  window.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  try {
+    // If assets fail to load over file://, React never mounts and this text never appears.
+    await expect(window.getByText("OSS Notice Generator")).toBeVisible({ timeout: 60000 });
+    // Confirm we exercised the production path, not the dev server.
+    expect(await window.evaluate(() => window.location.protocol)).toBe("file:");
+    // The blank-screen signature was ERR_FILE_NOT_FOUND on the bundled assets.
+    expect(consoleErrors.filter((e) => /ERR_FILE_NOT_FOUND/i.test(e))).toEqual([]);
+  } finally {
+    await app.close();
+  }
+});

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -61,14 +61,17 @@ async function createWindow(apiBase) {
       sandbox: false, // uses ESM preload
     },
   });
-  if (isDev) {
+  // ONOT_FRONTEND_DIR overrides the frontend location and forces the packaged-style file://
+  // load even when unpackaged. The file:// render E2E uses it to exercise the production path
+  // that dev-mode E2E (http://) cannot cover — the blank-screen class of bug (#68).
+  const frontendDir = process.env.ONOT_FRONTEND_DIR;
+  if (isDev && !frontendDir) {
     const base = process.env.VITE_DEV_SERVER ?? "http://localhost:5173";
     appOrigin = base;
     await mainWindow.loadURL(`${base}?apiBase=${encodeURIComponent(apiBase)}`);
   } else {
-    await mainWindow.loadFile(path.join(process.resourcesPath, "frontend", "index.html"), {
-      query: { apiBase },
-    });
+    const dir = frontendDir ?? path.join(process.resourcesPath, "frontend");
+    await mainWindow.loadFile(path.join(dir, "index.html"), { query: { apiBase } });
   }
 }
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -71,6 +71,18 @@ describe("App", () => {
     await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("bad sbom"));
   });
 
+  it("keeps action buttons disabled after a parse failure (no repeat errors)", async () => {
+    parseSbom.mockRejectedValue(new Error("bad sbom"));
+    render(<App />);
+    await userEvent.upload(screen.getByTestId("file-input"), new File(["x"], "x.json"));
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("bad sbom"));
+    // parsed === null after failure, so Generate/Download must stay disabled.
+    expect(screen.getByTestId("generate-preview")).toBeDisabled();
+    for (const btn of screen.getAllByRole("button", { name: /download/i })) {
+      expect(btn).toBeDisabled();
+    }
+  });
+
   it("downloads with the backend-provided filename and revokes the object URL", async () => {
     parseSbom.mockResolvedValue(parsed("demo", 1));
     renderNotice.mockResolvedValue({ blob: new Blob(["x"]), filename: "OSS_Notice_demo.html" });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -143,7 +143,7 @@ export default function App() {
               <Button
                 data-testid="generate-preview"
                 onClick={handleGenerate}
-                disabled={!file || status !== "idle"}
+                disabled={!parsed || status !== "idle"}
               >
                 {status === "rendering" ? t(uiLang, "rendering") : t(uiLang, "generate")}
               </Button>
@@ -153,7 +153,7 @@ export default function App() {
                     key={fmt}
                     variant="secondary"
                     onClick={() => handleDownload(fmt)}
-                    disabled={!file}
+                    disabled={!parsed}
                   >
                     {t(uiLang, "download")} {fmt}
                   </Button>

--- a/src/onot/api/routes.py
+++ b/src/onot/api/routes.py
@@ -47,18 +47,20 @@ async def _read_upload(file: UploadFile) -> tuple[bytes, str]:
         raise HTTPException(status_code=413, detail="uploaded file too large")
     if not data:
         raise HTTPException(status_code=400, detail="empty upload")
-    suffix = Path(file.filename or "").suffix  # extension only, no directory part (traversal guard)
-    return data, suffix
+    name = (
+        Path(file.filename or "").name or "upload"
+    )  # basename only, no directory part (traversal guard)
+    return data, name
 
 
-def _parse_bytes(data: bytes, suffix: str) -> IngestResult:
-    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
-        tmp.write(data)
-        path = tmp.name
-    try:
+def _parse_bytes(data: bytes, display_name: str) -> IngestResult:
+    # Write to a temp file under the upload's own basename so parse errors reference the
+    # user's filename rather than an internal tmpXXXX name. Format detection is content-based
+    # (see the ingest adapters), so a non-standard extension does not block parsing.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / display_name
+        path.write_bytes(data)
         return load_document(path)
-    finally:
-        Path(path).unlink(missing_ok=True)
 
 
 def _http_error(err: OnotError) -> HTTPException:
@@ -81,9 +83,9 @@ def formats() -> dict:
 
 @router.post("/api/parse")
 async def parse(file: UploadFile = File(...)) -> dict:
-    data, suffix = await _read_upload(file)
+    data, display_name = await _read_upload(file)
     try:
-        ingest_result = _parse_bytes(data, suffix)
+        ingest_result = _parse_bytes(data, display_name)
         resolved = LicenseResolver().resolve(ingest_result.document)
     except OnotError as err:
         raise _http_error(err) from err
@@ -109,7 +111,7 @@ async def render_notice(
     if lang not in _LANGS:
         raise HTTPException(status_code=400, detail=f"unsupported lang: {lang}")
 
-    data, suffix = await _read_upload(file)
+    data, display_name = await _read_upload(file)
     settings = Settings(
         default_lang=cast(Literal["en"], lang),
         company=CompanyConfig(
@@ -120,7 +122,7 @@ async def render_notice(
         ),
     )
     try:
-        ingest_result = _parse_bytes(data, suffix)
+        ingest_result = _parse_bytes(data, display_name)
         resolved = LicenseResolver(offline=settings.offline).resolve(ingest_result.document)
     except OnotError as err:
         raise _http_error(err) from err

--- a/src/onot/ingest/spdx.py
+++ b/src/onot/ingest/spdx.py
@@ -18,6 +18,47 @@ from onot.ingest.base import IngestResult
 _XML_SUFFIXES = (".rdf", ".rdf.xml", ".xml")
 
 
+def _serialization(data: bytes) -> str:
+    """Detect the SPDX serialization from content so parsing does not depend on the file extension.
+
+    spdx-tools' parse_file selects its reader from the file name, so a valid document with a
+    non-standard extension would fail. Returns "json"/"yaml"/"tagvalue"/"xml", or "" if unknown
+    (falls back to the extension-based reader).
+    """
+    head = data[:8192]
+    stripped = head.lstrip()
+    lowered = head.lower()
+    if stripped.startswith(b"<") or b"<rdf:rdf" in lowered or b"spdx.org/rdf" in lowered:
+        return "xml"
+    if stripped.startswith(b"{") or b'"spdxversion"' in lowered:
+        return "json"
+    if stripped.startswith(b"SPDXVersion:") or b"\nSPDXVersion:" in head:
+        return "tagvalue"
+    if b"spdxversion:" in lowered:
+        return "yaml"
+    return ""
+
+
+def _parse_spdx(path: Path, serialization: str) -> object:
+    path_str = str(path)
+    if serialization == "json":
+        from spdx_tools.spdx.parser.json import json_parser
+
+        return json_parser.parse_from_file(path_str)
+    if serialization == "yaml":
+        from spdx_tools.spdx.parser.yaml import yaml_parser
+
+        return yaml_parser.parse_from_file(path_str)
+    if serialization == "tagvalue":
+        from spdx_tools.spdx.parser.tagvalue import tagvalue_parser
+
+        return tagvalue_parser.parse_from_file(path_str)
+    # xml/rdf or unknown: fall back to the extension-based dispatcher (unchanged behavior)
+    from spdx_tools.spdx.parser.parse_anything import parse_file
+
+    return parse_file(path_str)
+
+
 class SpdxAdapter:
     format_id = "spdx"
 
@@ -35,12 +76,12 @@ class SpdxAdapter:
         return 0.0
 
     def parse(self, path: Path) -> IngestResult:
-        if path.name.lower().endswith(_XML_SUFFIXES):
-            reject_dangerous_xml(path.read_bytes())
-        from spdx_tools.spdx.parser.parse_anything import parse_file
-
+        data = path.read_bytes()
+        serialization = _serialization(data)
+        if serialization == "xml" or path.name.lower().endswith(_XML_SUFFIXES):
+            reject_dangerous_xml(data)
         try:
-            document = parse_file(str(path))
+            document = _parse_spdx(path, serialization)
         except Exception as exc:  # noqa: BLE001 — wrap the library exception as a domain exception
             raise ParseError(f"failed to parse SPDX document: {path.name}") from exc
         return IngestResult(document=spdx_document_to_notice(document))

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -41,6 +41,25 @@ def test_parse_formats(client, name):
     assert body["document"]["name"]
 
 
+def test_parse_nonstandard_extension_still_parses(client):
+    # O-2: a valid SPDX JSON must parse even when the uploaded name has a non-standard extension.
+    resp = client.post(
+        "/api/parse",
+        files={"file": ("renamed.weirdext", (FIX / "example.spdx.json").read_bytes())},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["document"]["name"] == "example-product"
+
+
+def test_parse_error_references_original_filename_not_temp(client):
+    # O-1: the error must name the user's file, never an internal tmpXXXX temp name.
+    resp = client.post("/api/parse", files={"file": ("broken.spdx.json", b"not a real sbom")})
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert "broken.spdx.json" in detail
+    assert "tmp" not in detail.lower()
+
+
 def test_parse_excel(client):
     resp = client.post("/api/parse", files=upload(SAMPLE))
     assert resp.status_code == 200

--- a/tests/ingest/test_spdx.py
+++ b/tests/ingest/test_spdx.py
@@ -11,7 +11,7 @@ import pytest
 
 from onot.domain.errors import ParseError
 from onot.ingest import load_document
-from onot.ingest.spdx import SpdxAdapter
+from onot.ingest.spdx import SpdxAdapter, _serialization
 
 FIX = Path(__file__).resolve().parents[1] / "fixtures" / "sbom"
 
@@ -54,4 +54,37 @@ def test_spdx_malformed_raises_parse_error(tmp_path):
     bad = tmp_path / "bad.spdx.json"
     bad.write_text('{"spdxVersion": "SPDX-2.3", "packages": [ this is not json ]}')
     with pytest.raises(ParseError):
+        SpdxAdapter().parse(bad)
+
+
+def test_spdx_json_parses_with_nonstandard_extension(tmp_path):
+    # O-2: serialization is detected from content, so a valid SPDX JSON parses even when
+    # the file extension is non-standard (spdx-tools' parse_file would otherwise fail on it).
+    weird = tmp_path / "renamed.weirdext"
+    weird.write_bytes((FIX / "example.spdx.json").read_bytes())
+    doc = load_document(weird).document
+    assert doc.name == "example-product"
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (b'{"spdxVersion": "SPDX-2.3"}', "json"),
+        (b"  \n{ }", "json"),
+        (b"SPDXVersion: SPDX-2.3\nDataLicense: CC0-1.0", "tagvalue"),
+        (b"spdxVersion: SPDX-2.3\n", "yaml"),
+        (b'<rdf:RDF xmlns:spdx="http://spdx.org/rdf/terms#">', "xml"),
+        (b"just some text", ""),
+    ],
+)
+def test_serialization_detects_format_from_content(data, expected):
+    # O-2: serialization is chosen by content so a non-standard extension does not break parsing.
+    assert _serialization(data) == expected
+
+
+def test_spdx_parse_error_uses_the_given_filename(tmp_path):
+    # O-1: the error references the file's own name, not an internal temp name.
+    bad = tmp_path / "broken.spdx.json"
+    bad.write_text("not a real sbom")
+    with pytest.raises(ParseError, match="broken.spdx.json"):
         SpdxAdapter().parse(bad)


### PR DESCRIPTION
Addresses the verification team's bug report. O-4's root cause was already fixed in 1.1.1; this adds the missing regression guard for it plus fixes for O-1..O-3.

## O-1 (Medium) — temp filename leaked in parse errors
Parse failures showed the server's internal temp name (`tmpXXXX.ext`) instead of the user's file. `_parse_bytes` now writes the upload to a temp file under its own basename, so ingest error messages (`registry.py`, `spdx.py`, `cyclonedx.py`, all using `path.name`) reference the real filename. Basename-only (traversal-safe).

## O-2 (Medium) — non-standard extension broke valid SPDX
`spdx-tools`' `parse_file` picks its reader from the file name, so a valid SPDX JSON saved as `.weirdext` failed. `SpdxAdapter` now detects the serialization from **content** (`_serialization`) and calls the matching sub-parser (`json_parser`/`yaml_parser`/`tagvalue_parser`); XML/RDF and unknown content fall back to the extension-based dispatcher (unchanged). CycloneDX was already content-based.

## O-3 (Low) — action buttons active after a parse failure
Generate preview / Download were gated on `!file`, so they stayed enabled after a failed parse and re-triggered the same error. Both now gate on `parsed` (which resets to `null` on upload and is only set on success).

## O-4 (Critical) — packaged file:// render guard
Root cause (absolute Vite asset paths over `file://`) was fixed in 1.1.1. The reason it escaped: the desktop E2E loads the frontend over `http://` (dev server), where absolute paths work. This adds `electron/e2e/file-load.e2e.mjs`, which launches the app in production `loadFile` mode against the built `frontend/dist` and asserts the UI mounts over `file://` with no `ERR_FILE_NOT_FOUND`. `main.mjs` gains an `ONOT_FRONTEND_DIR` seam to force that path; packaged behavior is unchanged when unset. Verified locally: passes on the fixed build.

## Tests
- Backend: `_serialization` detection (all branches), non-standard-extension parse, error-uses-original-filename — `tests/ingest/test_spdx.py`, `tests/api/test_api.py`
- Frontend: buttons disabled after parse failure — `frontend/src/App.test.tsx`
- E2E: file:// render — `electron/e2e/file-load.e2e.mjs`
- Full backend suite green, coverage 97% (gate 90%)