### PR TITLE
fix: QA report findings O-5..O-12 (crashes, injection, warnings, a11y)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install "onot[spdx,cyclonedx,excel,api]"   # from PyPI; add ,pdf for PDF out
 onot generate -i sbom.spdx.json -f html -f markdown --output-dir ./output
 
 #   -f/--format   html | text | markdown | pdf (repeatable)
-#   --lang        ko | en
+#   --lang        en
 #   --config      onot.yaml (company info, etc.)
 #   --online      fetch missing license texts remotely (offline by default)
 #   --stdout      write a single text format to stdout

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -91,7 +91,7 @@ export default function App() {
     <div className="mx-auto max-w-6xl p-6">
       <header className="mb-6">
         <h1 className="text-2xl font-bold">{t(uiLang, "title")}</h1>
-        <p className="text-sm text-zinc-500">{t(uiLang, "subtitle")}</p>
+        <p className="text-sm text-zinc-400">{t(uiLang, "subtitle")}</p>
       </header>
 
       <main>
@@ -108,15 +108,15 @@ export default function App() {
         <div className="space-y-4">
           <FileDropzone lang={uiLang} onFile={handleFile} fileName={file?.name} />
           {status === "parsing" && (
-            <p className="text-sm text-zinc-500">{t(uiLang, "parsing")}</p>
+            <p className="text-sm text-zinc-400">{t(uiLang, "parsing")}</p>
           )}
           {!file && status === "idle" && (
-            <p className="text-sm text-zinc-500">{t(uiLang, "noFile")}</p>
+            <p className="text-sm text-zinc-400">{t(uiLang, "noFile")}</p>
           )}
           {parsed && (
             <Card>
               <CardTitle>{parsed.document.name}</CardTitle>
-              <p className="text-sm text-zinc-500">
+              <p className="text-sm text-zinc-400">
                 {parsed.document.packages.length} {t(uiLang, "components")}
               </p>
               {parsed.warnings.length > 0 && (

--- a/frontend/src/components/FileDropzone.tsx
+++ b/frontend/src/components/FileDropzone.tsx
@@ -47,7 +47,7 @@ export function FileDropzone({
     >
       <UploadCloud className="h-8 w-8 text-zinc-400" aria-hidden />
       <p className="text-sm font-medium">{fileName ?? t(lang, "dropzone")}</p>
-      <p className="text-xs text-zinc-500">{t(lang, "dropzoneHint")}</p>
+      <p className="text-xs text-zinc-400">{t(lang, "dropzoneHint")}</p>
       <input
         type="file"
         aria-label={t(lang, "dropzone")}

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -41,7 +41,7 @@ export function SettingsPanel({
       <CardTitle>{t(uiLang, "settings")}</CardTitle>
 
       <fieldset className="mb-4">
-        <legend className="mb-1 text-xs font-medium text-zinc-500">{t(uiLang, "formats")}</legend>
+        <legend className="mb-1 text-xs font-medium text-zinc-400">{t(uiLang, "formats")}</legend>
         <div className="flex flex-wrap gap-3">
           {ALL_FORMATS.map((fmt) => (
             <label key={fmt} className="flex items-center gap-1.5 text-sm">
@@ -58,7 +58,7 @@ export function SettingsPanel({
 
       {COMPANY_FIELDS.map(({ key, label }) => (
         <label key={key} className="mb-2 block text-sm">
-          <span className="mb-1 block text-xs font-medium text-zinc-500">{t(uiLang, label)}</span>
+          <span className="mb-1 block text-xs font-medium text-zinc-400">{t(uiLang, label)}</span>
           <input
             value={value.company[key] ?? ""}
             onChange={(e) =>

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -20,7 +20,7 @@ export function CardTitle({ className, ...props }: HTMLAttributes<HTMLHeadingEle
   return (
     <h2
       className={cn(
-        "mb-3 text-sm font-semibold uppercase tracking-wide text-zinc-500",
+        "mb-3 text-sm font-semibold uppercase tracking-wide text-zinc-400",
         className,
       )}
       {...props}

--- a/src/onot/ingest/excel.py
+++ b/src/onot/ingest/excel.py
@@ -14,8 +14,11 @@ from pathlib import Path
 
 import openpyxl
 
+from onot.domain.errors import ParseError
 from onot.domain.models import Copyright, LicenseExpression, LicenseRef, NoticeDocument, Package
 from onot.ingest.base import IngestResult
+
+_REQUIRED_SHEETS = ("Document Info", "Package Info")
 
 # Standard SPDX spreadsheet column indices (0-based)
 _DOC_NAME_COL = 5
@@ -63,8 +66,16 @@ def _none_if_blank(value: object) -> str | None:
 
 
 def parse_excel(path: str | Path) -> NoticeDocument:
-    wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+    # A zip magic match (.zip/.docx/.jar) can reach this adapter, so openpyxl failures and
+    # missing-sheet errors are wrapped as ParseError (400) instead of surfacing as HTTP 500.
     try:
+        wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+    except Exception as exc:  # noqa: BLE001 — openpyxl raises BadZipFile/InvalidFileException/etc.
+        raise ParseError(f"failed to open Excel workbook: {Path(path).name}") from exc
+    try:
+        missing = [s for s in _REQUIRED_SHEETS if s not in wb.sheetnames]
+        if missing:
+            raise ParseError(f"Excel workbook is missing required sheet(s): {', '.join(missing)}")
         name = _document_name(wb)
         packages = _packages(wb)
         refs = _extracted_licenses(wb)

--- a/src/onot/ingest/spdx.py
+++ b/src/onot/ingest/spdx.py
@@ -69,6 +69,10 @@ class SpdxAdapter:
         stripped = head.lstrip()
         if stripped.startswith(b"SPDXVersion:") or b"\nSPDXVersion:" in head:
             return 0.95
+        # YAML SPDX uses an unquoted lowercase key (spdxVersion:), which the JSON/tag-value
+        # checks above miss. Detect it by content so a .yaml/extensionless file is recognized.
+        if b"spdxversion:" in lowered:
+            return 0.9
         if b"spdx.org/rdf" in lowered or (b"<rdf:rdf" in lowered and b"spdx" in lowered):
             return 0.85
         if path.name.lower().endswith((".spdx", ".spdx.json", ".spdx.yaml", ".spdx.yml")):

--- a/src/onot/license/resolver.py
+++ b/src/onot/license/resolver.py
@@ -53,6 +53,8 @@ class LicenseResolver:
         for pkg in doc.packages:
             expr = pkg.effective_expression
             if expr is None:
+                # A compliance notice must flag missing license info rather than pass silently.
+                warnings.append(f"no license information for {pkg.display}")
                 continue
             try:
                 syms = symbols(expr.raw)
@@ -93,10 +95,14 @@ class LicenseResolver:
                 used_by=used_by,
             )
         if license_id in ref_text:
+            text = ref_text[license_id]
+            if not text.strip():
+                # Defined but empty extracted text leaves a blank license section — flag it.
+                warnings.append(f"missing license text for {license_id}")
             return License(
                 license_id=license_id,
                 name=ref_name.get(license_id, license_id),
-                text=ref_text[license_id],
+                text=text,
                 used_by=used_by,
             )
         # Found neither in the catalog nor embedded: supplement remotely if online, otherwise unknown

--- a/src/onot/rendering/base.py
+++ b/src/onot/rendering/base.py
@@ -16,7 +16,7 @@ import jinja2
 from onot.core.config import Settings
 from onot.domain.models import NoticeDocument
 from onot.rendering.context import build_context
-from onot.rendering.filters import anchor, license_links, md_code_block
+from onot.rendering.filters import anchor, license_links, md_cell, md_code_block, md_inline, oneline
 from onot.rendering.i18n import Translator
 
 
@@ -31,6 +31,9 @@ def make_environment(autoescape_formats: list[str]) -> jinja2.Environment:
     env.filters["anchor"] = anchor
     env.filters["license_links"] = license_links
     env.filters["md_code_block"] = md_code_block
+    env.filters["md_cell"] = md_cell
+    env.filters["md_inline"] = md_inline
+    env.filters["oneline"] = oneline
     return env
 
 

--- a/src/onot/rendering/filters.py
+++ b/src/onot/rendering/filters.py
@@ -32,6 +32,41 @@ def license_links(expression: str, known_ids: Iterable[str]) -> Markup:
     return Markup("".join(parts))
 
 
+def md_cell(value: object) -> str:
+    """Escape untrusted SBOM/user text for a Markdown table cell.
+
+    Package names/versions come from third-party components, so pipes and newlines would break
+    the table and link syntax could inject active links. Escapes the structural characters.
+    """
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace("|", "\\|")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+        .replace("\r\n", " ")
+        .replace("\n", " ")
+        .replace("\r", " ")
+    )
+
+
+def md_inline(value: object) -> str:
+    """Neutralize Markdown link syntax and newlines for untrusted values used inline (not a table cell)."""
+    return (
+        str(value)
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+        .replace("\r\n", " ")
+        .replace("\n", " ")
+        .replace("\r", " ")
+    )
+
+
+def oneline(value: object) -> str:
+    """Flatten newlines so an untrusted value cannot forge structural lines in plain-text output."""
+    return str(value).replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+
+
 def md_code_block(text: str) -> str:
     """Wrap in a Markdown code fence. Uses a fence longer than any backtick run in the body to prevent fence escaping."""
     longest = max((len(run) for run in re.findall(r"`+", text)), default=0)

--- a/src/onot/rendering/templates/markdown/notice.md.jinja
+++ b/src/onot/rendering/templates/markdown/notice.md.jinja
@@ -11,7 +11,7 @@ _{{ t("notice.generated", date=ctx.generated) }}_
 | {{ t("table.name") }} | {{ t("table.version") }} | {{ t("table.license") }} | {{ t("table.copyright") }} |
 |---|---|---|---|
 {% for pkg in doc.packages %}
-| {{ pkg.name }} | {{ pkg.version }} | {{ pkg.expression_display | replace("|", "\\|") }} | {{ pkg.copyright_display | replace("|", "\\|") | replace("\n", " ") }} |
+| {{ pkg.name | md_cell }} | {{ pkg.version | md_cell }} | {{ pkg.expression_display | md_cell }} | {{ pkg.copyright_display | md_cell }} |
 {% endfor %}
 
 ## {{ t("section.licenses") }}
@@ -30,13 +30,13 @@ _{{ t("notice.generated", date=ctx.generated) }}_
 {{ t("offer.body") }}
 {% if ctx.source_url %}
 
-{{ t("offer.source_url", url=ctx.source_url) }}
+{{ t("offer.source_url", url=ctx.source_url | md_inline) }}
 {% endif %}
 {% if ctx.email %}
 
-{{ t("closing", email=ctx.email) }}
+{{ t("closing", email=ctx.email | md_inline) }}
 {% endif %}
 {% if ctx.copyright_holder %}
 
-{{ t("footer.copyright", year=ctx.copyright_year or "", holder=ctx.copyright_holder) }}
+{{ t("footer.copyright", year=ctx.copyright_year or "", holder=ctx.copyright_holder | md_inline) }}
 {% endif %}

--- a/src/onot/rendering/templates/text/notice.txt.jinja
+++ b/src/onot/rendering/templates/text/notice.txt.jinja
@@ -27,11 +27,11 @@
 {{ t("offer.title") }}
 {{ t("offer.body") }}
 {% if ctx.source_url %}
-{{ t("offer.source_url", url=ctx.source_url) }}
+{{ t("offer.source_url", url=ctx.source_url | oneline) }}
 {% endif %}
 {% if ctx.email %}
-{{ t("closing", email=ctx.email) }}
+{{ t("closing", email=ctx.email | oneline) }}
 {% endif %}
 {% if ctx.copyright_holder %}
-{{ t("footer.copyright", year=ctx.copyright_year or "", holder=ctx.copyright_holder) }}
+{{ t("footer.copyright", year=ctx.copyright_year or "", holder=ctx.copyright_holder | oneline) }}
 {% endif %}

--- a/tests/ingest/test_excel_robust.py
+++ b/tests/ingest/test_excel_robust.py
@@ -5,8 +5,12 @@
 
 from __future__ import annotations
 
-import openpyxl
+import zipfile
 
+import openpyxl
+import pytest
+
+from onot.domain.errors import ParseError
 from onot.ingest.excel import parse_excel
 
 
@@ -52,3 +56,22 @@ def test_blank_rows_skipped(tmp_path):
     _build(path, [[None], ["", None], ["keep"]])
     doc = parse_excel(path)
     assert [pk.name for pk in doc.packages] == ["keep"]
+
+
+def test_non_excel_zip_raises_parse_error(tmp_path):
+    # O-5: a zip that is not an xlsx (.zip/.docx/.jar) must be a 400-class ParseError, not a 500.
+    path = tmp_path / "fake.zip"
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("a.txt", "hi")
+    with pytest.raises(ParseError):
+        parse_excel(path)
+
+
+def test_missing_required_sheet_raises_parse_error(tmp_path):
+    # O-6: a valid xlsx without the required sheets must be a ParseError, not a KeyError/500.
+    path = tmp_path / "nosheets.xlsx"
+    wb = openpyxl.Workbook()
+    wb.active.title = "Random"
+    wb.save(path)
+    with pytest.raises(ParseError, match="required sheet"):
+        parse_excel(path)

--- a/tests/ingest/test_spdx.py
+++ b/tests/ingest/test_spdx.py
@@ -5,9 +5,11 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
+import yaml
 
 from onot.domain.errors import ParseError
 from onot.ingest import load_document
@@ -80,6 +82,16 @@ def test_spdx_json_parses_with_nonstandard_extension(tmp_path):
 def test_serialization_detects_format_from_content(data, expected):
     # O-2: serialization is chosen by content so a non-standard extension does not break parsing.
     assert _serialization(data) == expected
+
+
+def test_spdx_yaml_is_detected_by_content_and_parses(tmp_path):
+    # O-7: SPDX YAML uses an unquoted lowercase key (spdxVersion:); it must be recognized by
+    # content and parse even with a plain .yaml name (which file-name-based detection misses).
+    data = yaml.safe_dump(json.loads((FIX / "example.spdx.json").read_text()))
+    assert SpdxAdapter().sniff(Path("plain.yaml"), data.encode()[:8192]) > 0
+    p = tmp_path / "plain.yaml"
+    p.write_text(data)
+    assert load_document(p).document.name == "example-product"
 
 
 def test_spdx_parse_error_uses_the_given_filename(tmp_path):

--- a/tests/license/test_resolve.py
+++ b/tests/license/test_resolve.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-from onot.domain.models import LicenseExpression, NoticeDocument, Package
-from onot.license import resolve
+from onot.domain.models import LicenseExpression, LicenseRef, NoticeDocument, Package
+from onot.license import resolve, resolve_with_warnings
 
 
 def _doc():
@@ -37,3 +37,23 @@ def test_resolve_deterministic_and_sorted():
 def test_resolve_skips_packages_without_license():
     doc = NoticeDocument(name="p", packages=(Package(name="x"),))
     assert resolve(doc).licenses == ()
+
+
+def test_resolve_warns_on_missing_license_information():
+    # O-9: a package with no license info must surface a warning, not pass silently.
+    doc = NoticeDocument(name="p", packages=(Package(name="x", version="1"),))
+    warnings = resolve_with_warnings(doc).warnings
+    assert any("no license information for x 1" in w for w in warnings)
+
+
+def test_resolve_warns_on_empty_license_ref_text():
+    # O-9: a referenced LicenseRef with blank extracted text yields an empty section -> warn.
+    doc = NoticeDocument(
+        name="p",
+        packages=(
+            Package(name="x", version="1", license_concluded=LicenseExpression(raw="LicenseRef-1")),
+        ),
+        license_refs=(LicenseRef(identifier="LicenseRef-1", extracted_text=""),),
+    )
+    result = resolve_with_warnings(doc)
+    assert any("missing license text for LicenseRef-1" in w for w in result.warnings)

--- a/tests/rendering/test_escape.py
+++ b/tests/rendering/test_escape.py
@@ -5,7 +5,8 @@
 
 from __future__ import annotations
 
-from onot.domain.models import Copyright, License, NoticeDocument, Package
+from onot.core.config import CompanyConfig, Settings
+from onot.domain.models import Copyright, License, LicenseExpression, NoticeDocument, Package
 from onot.rendering import render
 
 
@@ -28,3 +29,31 @@ def test_html_escapes_product_and_license_text():
     assert "A &amp; B &lt;co&gt;" in html
     assert "a &lt; b &amp; c" in html
     assert "<co>" not in html
+
+
+def test_markdown_escapes_package_name_pipe_and_link():
+    # O-8: untrusted package name/version must not break the table or inject an active link.
+    doc = NoticeDocument(
+        name="prod",
+        packages=(
+            Package(
+                name="evil | X | [a](javascript:alert(1))",
+                version="1",
+                license_concluded=LicenseExpression(raw="MIT"),
+            ),
+        ),
+    )
+    md = render(doc, "markdown")
+    row = next(line for line in md.splitlines() if "evil" in line)
+    assert "\\|" in row  # pipe escaped -> cell not split
+    assert "\\[a\\]" in row  # link syntax neutralized
+    assert "MIT" in row  # all cells stayed on one row (table structure intact)
+
+
+def test_markdown_escapes_company_field_link():
+    # O-10: company config fields are untrusted in Markdown output too.
+    doc = NoticeDocument(name="prod")
+    settings = Settings(company=CompanyConfig(copyright_holder="[x](javascript:alert(1))"))
+    md = render(doc, "markdown", settings=settings)
+    line = next(line for line in md.splitlines() if "javascript" in line)
+    assert "\\[x\\]" in line


### PR DESCRIPTION
Second batch from the verification team's report (O-1..O-4 shipped in #75). Fixes crashes, output injection, a compliance gap, a doc error, and a contrast issue.

## Backend
- **O-5 (Medium)** — non-Excel zip uploads (`.zip/.docx/.jar`) reached the Excel adapter (PK-magic sniff) and crashed with HTTP 500. `parse_excel` now wraps `openpyxl` failures as `ParseError` (400).
- **O-6 (Medium)** — a valid xlsx missing the `Document Info`/`Package Info` sheets raised `KeyError` → 500. Now checks required sheets and raises `ParseError` with a clear message.
- **O-7 (Medium)** — SPDX YAML was rejected though advertised. `SpdxAdapter.sniff` now detects the unquoted lowercase `spdxVersion:` key by content, so `.yaml`/extensionless SPDX is recognized; the content-based reader selection (from O-2) handles the parse.
- **O-9 (Medium)** — missing license info passed silently. The resolver now warns for packages with no license expression and for referenced `LicenseRef`s with empty extracted text.

## Rendering (injection)
- **O-8 (Medium) / O-10 (Low)** — Markdown notices did not escape package name/version or company-config fields, allowing table breakage and `[x](javascript:...)` link injection. Added `md_cell`/`md_inline`/`oneline` filters; applied to Markdown table cells and the inline company fields (Markdown + text). HTML output was already autoescaped.

## Docs / a11y
- **O-11 (Low)** — README advertised `--lang ko | en`; onot is English-only. Corrected to `en`.
- **O-12 (Medium)** — muted text used `text-zinc-500`, failing WCAG AA contrast (4.5:1) on the dark theme. Bumped to `text-zinc-400` across App, SettingsPanel, FileDropzone, Card.

## Tests
- Backend regression tests for O-5 (fake zip → ParseError), O-6 (missing sheet → ParseError), O-7 (YAML detected + parses), O-8/O-10 (Markdown escaping), O-9 (missing-license + empty-ref warnings).
- Full backend suite green (189 passed), coverage 97%; frontend 25 tests green.

O-12 contrast is not asserted automatically (jsdom cannot compute contrast; the axe test disables color-contrast). The class change is verified manually against the report's ratios.