### PR TITLE
docs: correct Windows download and log-path details after real-device verification

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -66,8 +66,8 @@ license texts are included as well.
 ![Notice preview](images/04-preview.png)
 
 Once you've reviewed it, click the button for the format you want — such as
-**Download html** or **Download markdown** — to save the file. For PDF, a dialog asks
-where to save.
+**Download html**, **Download markdown**, or **Download pdf**. For every format a
+"Save as" dialog opens so you can choose where to save the file.
 
 ## Frequently asked questions
 

--- a/docs/WINDOWS_QA_CHECKLIST.md
+++ b/docs/WINDOWS_QA_CHECKLIST.md
@@ -27,7 +27,7 @@ Defender real-time protection on. Record the app version tested.
 - [ ] No console window flashes when the app starts.
 - [ ] The app becomes usable within a reasonable time even on the first launch (Defender
       scan). If startup fails, the error dialog offers **Retry**/**Quit** and names the log
-      file (`%APPDATA%\onot\sidecar.log` under the app's userData path).
+      file (`%APPDATA%\onot-desktop\sidecar.log` under the app's userData path).
 
 ## Generate a notice
 

--- a/docs/WINDOWS_TEST_HANDOFF.md
+++ b/docs/WINDOWS_TEST_HANDOFF.md
@@ -131,7 +131,8 @@ With the app open:
 - Uncheck every output format: the "select at least one output format" hint shows;
   re-check html.
 - Click "Generate preview"; then download WITHOUT previewing first (both should work).
-- Download html, text, markdown: files save with sensible names.
+- Download html, text, markdown: each opens a "Save as" dialog and saves with a sensible
+  default name.
 - Download pdf: a Save dialog appears; cancel it once (a "PDF save cancelled" note
   appears); save it once (a valid PDF is written).
 - Upload a random `.json` that is not an SBOM: a readable error with a recovery hint
@@ -143,7 +144,10 @@ With the app open:
   ```
   where /r "%APPDATA%" sidecar.log
   ```
-  (userData is typically `%APPDATA%\onot\sidecar.log`; do not assume, search for it.)
+  (userData is typically `%APPDATA%\onot-desktop\sidecar.log`; do not assume, search
+  for it.) An empty log after a successful launch is normal: the sidecar runs uvicorn at
+  `log_level="warning"`, so a clean startup writes nothing. The log fills only when the
+  sidecar emits a warning or error — exactly the failure case you would be diagnosing.
 - No orphan sidecar after quitting the app:
   ```
   tasklist | findstr /i "onot-sidecar onot.exe"


### PR DESCRIPTION
## What

Corrects three documentation inaccuracies found while verifying the installed
**v1.1.1** Windows build end to end on a real Windows 11 machine (frozen
`onot.exe` + frozen `onot-sidecar.exe`, driven against the actual installed binary).

All documented functionality passed; these are doc-accuracy fixes, no code changes.

## Changes

- **`USER_GUIDE.md`** — html/text/markdown downloads also open a "Save as"
  dialog. The production main process registers no `will-download` handler, so
  Electron's default prompts for a location on **every** format, not just PDF.
  The old wording implied only PDF asks where to save.
- **`WINDOWS_QA_CHECKLIST.md` + `WINDOWS_TEST_HANDOFF.md`** — the sidecar log
  lives under `%APPDATA%\onot-desktop\sidecar.log`, not `%APPDATA%\onot\`
  (electron-builder `productName` is `onot-desktop`).
- **`WINDOWS_TEST_HANDOFF.md`** — note that an empty `sidecar.log` after a
  successful launch is expected (`uvicorn` runs at `log_level="warning"`, so a
  clean startup writes nothing), and align the Step 4 download wording.

## Verification evidence

Verified working on the installed build: `file://` render (no blank screen,
`ERR_FILE_NOT_FOUND=0`), Try-a-sample parse, all four format download buttons,
preview render, html/text/md saved with sensible names, valid PDF export + cancel
note, non-SBOM and truncated-SBOM error hints, and no orphan sidecar after quit.