### PR TITLE
chore(release): 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-07-02
+
+### Fixed
+
+- Parse errors now reference the uploaded file's own name instead of an internal
+  temporary name.
+- SPDX documents with a non-standard extension, and SPDX YAML, are now detected by
+  content and parsed instead of being rejected by extension.
+- Non-Excel zip uploads and Excel files missing required sheets now return a clear
+  400 error instead of crashing with HTTP 500.
+- Markdown and text notices now escape package names/versions and company fields,
+  preventing table breakage and link injection.
+- Missing or empty license information now raises a warning instead of passing
+  silently.
+
+### Added
+
+- "Try a sample" loads a bundled example SBOM so first-time users can preview a
+  notice without their own file.
+- The file picker filters toward SBOM types, and upload/parse errors now carry a
+  plain-language recovery hint.
+
+### Changed
+
+- Preview and download stay disabled until a file parses successfully, and an empty
+  output-format selection now explains why downloads are unavailable.
+- A cancelled PDF save is reported instead of appearing to do nothing.
+- Muted UI text was darkened to meet WCAG AA contrast.
+- Desktop: the sidecar no longer flashes a console window on Windows, its output is
+  captured to a log file, the first-run health timeout is longer on Windows, and a
+  failed start shows a Retry/Quit dialog naming the log instead of quitting silently.
+
 ## [1.1.1] - 2026-07-01
 
 ### Fixed
@@ -13,24 +45,12 @@ All notable changes to this project are documented here. The format is based on
 - Packaged desktop app showed a blank screen on Windows: the bundled frontend
   referenced assets by absolute path, which fails over `file://`. Assets are now
   emitted with relative paths so the renderer loads correctly (#68).
-- Parse errors now reference the uploaded file's own name instead of an internal
-  temporary name.
-- SPDX documents with a non-standard extension, and SPDX YAML, are now detected by
-  content and parsed instead of being rejected by extension.
-- Non-Excel zip uploads and Excel files missing required sheets now return a clear
-  400 error instead of crashing with HTTP 500.
-- Markdown notices now escape package names/versions and company fields, preventing
-  table breakage and link injection.
-- Missing or empty license information now raises a warning instead of passing
-  silently.
 - Cleared High/Critical dependency advisories (electron, undici, form-data).
 
 ### Changed
 
 - The app and generated notices are English-only for the global release; the Korean
   locale was removed.
-- Preview and download stay disabled until a file parses successfully.
-- Muted UI text was darkened to meet WCAG AA contrast.
 
 ## [1.1.0] - 2026-06-03
 
@@ -65,7 +85,8 @@ generator.
 - Initial public release: PyQt-based desktop generator that produced OSS notices
   from SPDX documents.
 
-[Unreleased]: https://github.com/sktelecom/onot/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/sktelecom/onot/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/sktelecom/onot/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/sktelecom/onot/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/sktelecom/onot/compare/1.0.0...v1.1.0
 [1.0.0]: https://github.com/sktelecom/onot/releases/tag/1.0.0

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onot-desktop",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "packageManager": "pnpm@10.34.4",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onot-frontend",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "packageManager": "pnpm@10.34.4",
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "onot"
-version = "1.1.1"
+version = "1.1.2"
 description = "Generate open source software notices from SBOM/SPDX documents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/onot/__init__.py
+++ b/src/onot/__init__.py
@@ -3,4 +3,4 @@
 
 """onot — open source software notice generator from SBOM/SPDX documents."""
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"


### PR DESCRIPTION
Cuts 1.1.2. All user-facing work since the v1.1.1 tag — the QA report fixes (O-1..O-12) and the Windows onboarding hardening (#75, #76, #77) — is on main but unreleased, and the source version was never bumped past 1.1.1.

## Changes
- Version bump 1.1.1 → 1.1.2 in `pyproject.toml`, `src/onot/__init__.py`, `electron/package.json`, `frontend/package.json`.
- CHANGELOG correction: the O-1..O-12 fixes and onboarding items were merged **after** the v1.1.1 tag, so they move from `[1.1.1]` into a new `[1.1.2]` section. `[1.1.1]` now reflects only what actually shipped in that tag (the #68 blank-screen fix, English-only, and the High/Critical dependency clears).

## What 1.1.2 ships
Parse robustness (filename in errors, content-based SPDX/YAML detection, Excel 500→400), notice injection escaping (Markdown/text), missing-license warnings, first-run UX (Try a sample, accept filter, empty-format hint, recovery hints, PDF-cancel feedback), WCAG AA contrast, and desktop packaging fixes (windowsHide, sidecar log capture, longer Windows timeout, Retry/Quit dialog).

## After merge
Push the `v1.1.2` tag; `release.yml` builds the Windows/macOS installers, publishes the GitHub Release, and publishes to PyPI.