### PR TITLE
ci(release): serialize desktop publish matrix to avoid duplicate releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ jobs:
       contents: write # Upload installers to GitHub Releases
     strategy:
       fail-fast: false
+      # Serialize the OS legs: both run `electron-builder --publish always`, and publishing
+      # concurrently let each leg create its own GitHub release for the same tag (a race that
+      # split the v1.1.2 assets across two releases). max-parallel: 1 makes the second leg find
+      # and upload to the release the first leg already created.
+      max-parallel: 1
       matrix:
         os: [windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Problem
The v1.1.2 release was split across two GitHub release objects for the same tag: the "Latest" one had only the macOS `.dmg` + SBOM, while `onot-Setup-1.1.2.exe` landed on a duplicate release. Users clicking Latest got no Windows installer. (The v1.1.2 assets have since been consolidated onto one release by hand.)

## Cause
`publish-desktop` runs the windows and macos legs concurrently, each with `electron-builder --publish always`. Publishing at the same time, each leg created its own release for the tag (a known electron-builder multi-CI race). It happened to not trigger on v1.1.0/v1.1.1 but did on v1.1.2.

## Fix
`strategy.max-parallel: 1` serializes the legs, so the first creates the release and the second finds it by tag and uploads to it. The release-time asset-name check added earlier (`Verify published installer names match the docs`) already catches this class of failure if it recurs.

A heavier alternative (build artifacts with `--publish never`, then a single job creates the release and uploads all OS assets) is more robust but a larger change; serialization is the minimal reliable fix.