### PR TITLE
ci(release): install the build frontend from hash-pinned requirements

### DIFF
--- a/.github/requirements/build.txt
+++ b/.github/requirements/build.txt
@@ -1,0 +1,24 @@
+# Hash-pinned requirements for the PyPI publish job in .github/workflows/release.yml.
+# Installed with `pip install --require-hashes`, which OpenSSF Scorecard's
+# Pinned-Dependencies check requires for pip commands.
+#
+# Resolved for the publish job's environment only: CPython 3.12 on Linux.
+# Markers that never apply there (colorama on Windows, tomli below 3.11,
+# importlib-metadata below 3.10.2) are therefore omitted.
+#
+# To update: bump the version, then take the sha256 digests of the wheel and
+# the sdist from https://pypi.org/pypi/<name>/<version>/json.
+
+build==1.5.0 \
+    --hash=sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f \
+    --hash=sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647
+
+# build dependency: packaging>=24.0
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
+
+# build dependency: pyproject_hooks
+pyproject_hooks==1.2.0 \
+    --hash=sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913 \
+    --hash=sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
           sed -i -E "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
       - name: Build sdist and wheel
         run: |
-          python -m pip install build==1.5.0
+          python -m pip install --require-hashes -r .github/requirements/build.txt
           python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1


### PR DESCRIPTION
## Problem

OpenSSF Scorecard raises a Pinned-Dependencies finding (medium, score 6) on `.github/workflows/release.yml:91`:

```
score is 6: pipCommand not pinned by hash
```

The PyPI publish job pins the build frontend by version but not by artifact hash. A re-uploaded or compromised distribution on the index would be installed without any integrity failure.

## Changes

- Add `.github/requirements/build.txt` holding the build frontend and its transitive dependencies, each with the sha256 digests of both the wheel and the sdist.
- Install it with `--require-hashes` in the publish job. That flag rejects any requirement without a hash, which is why `packaging` and `pyproject_hooks` are listed explicitly rather than resolved implicitly.

The file targets the publish job's environment only, CPython 3.12 on Linux, so markers that never apply there are left out: `colorama` (Windows), `tomli` (Python below 3.11), `importlib-metadata` (below 3.10.2).

`packaging` is pinned to 26.2 rather than the current 26.3. 26.3 was published nine days ago; 26.2 has been available since April and satisfies the `packaging>=24.0` requirement.

## Verification

The release workflow only runs on tag pushes, so this was verified locally on CPython 3.12 instead:

```
$ python -m pip install --require-hashes -r .github/requirements/build.txt
Successfully installed build-1.5.0 packaging-26.2 pyproject_hooks-1.2.0

$ python -m build
Successfully built onot-1.1.2.tar.gz and onot-1.1.2-py3-none-any.whl
```

## Maintenance note

Version bumps in this file now require updating the digests as well. The header comment records where to take them from: `https://pypi.org/pypi/<name>/<version>/json`.
