### PR TITLE
chore(deps): bump tar to 7.5.22 in electron

### DIFF
--- a/electron/pnpm-lock.yaml
+++ b/electron/pnpm-lock.yaml
@@ -955,8 +955,8 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  tar@7.5.19:
-    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   temp-file@3.4.0:
@@ -1316,7 +1316,7 @@ snapshots:
       proper-lockfile: 4.1.2
       resedit: 1.7.2
       semver: 7.7.4
-      tar: 7.5.19
+      tar: 7.5.22
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
       unzipper: 0.12.5
@@ -1937,7 +1937,7 @@ snapshots:
       nopt: 9.0.0
       proc-log: 6.1.0
       semver: 7.7.4
-      tar: 7.5.19
+      tar: 7.5.22
       tinyglobby: 0.2.17
       undici: 6.28.0
       which: 6.0.1
@@ -2149,7 +2149,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  tar@7.5.19:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
## Problem

With the SCA check green again, OpenSSF Scorecard's Vulnerabilities check (score 9) still reports one finding on `main`:

```
Warn: Project is vulnerable to: https://osv.dev/GHSA-r292-9mhp-454m
```

`tar` 7.5.19 has uncontrolled recursion in `mapHas`/`filesFilter`, so a crafted archive with long member paths can trigger an uncatchable stack overflow. The advisory is rated moderate, which keeps it below the SCA job's High cutoff, but Scorecard scans with OSV and reports it regardless of severity.

## Changes

`tar` 7.5.19 → 7.5.22 in the electron workspace. It is a transitive dev dependency and the fix is a semver-compatible patch release, so only the lockfile changes, following the same approach as #98 and #110.

## Verification

```
$ osv-scanner scan --lockfile=electron/pnpm-lock.yaml
Scanned electron/pnpm-lock.yaml file and found 276 packages
No issues found

$ osv-scanner scan --lockfile=frontend/pnpm-lock.yaml
Scanned frontend/pnpm-lock.yaml file and found 200 packages
No issues found
```