### PR TITLE
ci: move the Node jobs from 20 to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
       - run: pnpm -C frontend install --frozen-lockfile
@@ -95,7 +95,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
-          node-version: 20
+          node-version: 24
       - run: pip install -e ".[spdx,cyclonedx,excel,api]" pyinstaller==6.20.0
       - run: pnpm -C frontend install --frozen-lockfile && pnpm -C frontend build
       - name: build frozen sidecar
@@ -146,7 +146,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
-          node-version: 20
+          node-version: 24
       - run: pip install -e ".[spdx,cyclonedx,excel,api]"
       - run: pnpm -C frontend install --frozen-lockfile && pnpm -C frontend build
       - run: pnpm -C electron install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
-          node-version: 20
+          node-version: 24
       - run: pip install -e ".[spdx,cyclonedx,excel,api]" pyinstaller==6.20.0
       - run: pnpm -C frontend install --frozen-lockfile && pnpm -C frontend build
       - name: build frozen sidecar


### PR DESCRIPTION
## Problem

Every Node job in CI pins `node-version: 20`. Node 20 reached end of life on 2026-04-30, so `frontend`, `build-desktop`, `e2e-desktop` and the release workflow's `publish-desktop` have been building and testing on an unsupported runtime for over three months.

| Line | Supported until |
|---|---|
| v20 | 2026-04-30 (ended) |
| v22 | 2027-04-30 |
| v24 | 2028-04-30 (current LTS) |

## Why now

The same pin is what blocks #104 (jsdom 29 → 30). The chain is:

- jsdom 30 depends on `undici ^8.9.0`; jsdom 29 depended on `undici ^7.25.0`
- undici 8 declares `engines: { node: ">=22.19.0" }`
- pnpm only warns on an engines mismatch instead of refusing to install

So on Node 20 the install succeeds and the failure surfaces at runtime, killing every vitest worker before a single test runs:

```
Caused by: TypeError: webidl.util.markAsUncloneable is not a function
 ❯ new CacheStorage  undici@8.10.0/lib/web/cache/cachestorage.js:20
 ❯ Object.<anonymous>  jsdom@30.0.1/lib/api.js:12
```

`markAsUncloneable` is a `node:worker_threads` API that Node 20 does not provide.

## Changes

`node-version: 20` → `24` in three places in `ci.yml` and one in `release.yml`. Nothing else changes; no `engines` field is added to the workspaces.

## Follow-up

Once this lands, #104 can be rebased and re-run on Node 24.
