### PR TITLE
ci: cap artifact retention at 7 days

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
         with:
           name: onot-${{ matrix.os }}
           path: electron/dist-electron/
+          retention-days: 7
 
   e2e-desktop:
     needs: [build-desktop]

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -93,3 +93,4 @@ jobs:
         with:
           name: sbom-cyclonedx
           path: sbom.cdx.json
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Add retention-days: 7 to the desktop installer upload (onot-${matrix.os}) and the SBOM upload in security.yml.
- Both defaulted to GitHub's 90-day retention, and the desktop installer artifacts (dmg/exe, matrix per PR/push) accumulated to ~138GB before cleanup.

## Test plan
- [ ] CI passes once the account-level Actions lock clears