### PR TITLE
fix(deps): bump fast-uri to 3.1.7 in electron

### DIFF
--- a/electron/pnpm-lock.yaml
+++ b/electron/pnpm-lock.yaml
@@ -441,8 +441,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1266,7 +1266,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1628,7 +1628,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
Clears the four high-severity `fast-uri` advisories (GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp) that fail the grype gate in the security workflow.

The lockfile pinned 3.1.5. Every 3.x range in those advisories ends below 3.1.6, and `ajv` asks for `^3.0.1`, so refreshing the lockfile moves it to 3.1.7. The diff is four lines; no other package changes.

Dependabot could not produce this update because the advisory records carry no patched-versions, so it kept reporting the update as impossible even though 3.1.6 and 3.1.7 are published on npm. That is why its runs have been failing daily since 2026-09-02.

`fast-uri` reaches the tree through `ajv` under `electron-builder`, a devDependency, so it never ships in the packaged app.

Verified on haksungjang/onot#2 while Actions is unavailable here: `ci` and `security` both green, including `SCA (SBOM + grype)`.