### PR TITLE
ci(release): make the release workflow callable from another repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,53 @@ name: release
 # be registered once on PyPI (Owner: sktelecom, Repo: onot, Workflow: release.yml,
 # Environment: pypi). Until registration, the publish-pypi job fails, but this does not
 # affect regular CI.
+#
+# The workflow is also callable from another repository, so a release can be built on
+# that repository's runners while the assets land here. The build definition is called
+# rather than copied, so the two never drift. `owner`/`repo` retarget the GitHub
+# Release; leaving them empty keeps the current behaviour, so a fork that calls this
+# without them releases under its own account.
+#
+# Uploading needs PUBLISH_TOKEN, a token with contents:write on the target repository.
+# Without it, and without `publish`, the installers are still built and their names
+# verified, and nothing reaches the release.
+#
+# A caller is a separate entry point for PyPI's OIDC check: the `workflow` claim names
+# the caller's file, not this one, so the calling repository needs its own trusted
+# publisher entry on PyPI.
 on:
   push:
     tags: ["v*"]
+  workflow_call:
+    inputs:
+      owner:
+        description: "Repository owner to publish the release under (default: this repository's owner)"
+        required: false
+        type: string
+        default: ""
+      repo:
+        description: "Repository name to publish the release under (default: this repository)"
+        required: false
+        type: string
+        default: ""
+      publish:
+        description: "Upload the built assets (off = build and verify only)"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      PUBLISH_TOKEN:
+        description: "Token with contents:write on the target repository (default: the run GITHUB_TOKEN)"
+        required: false
 
 permissions:
   contents: read
+
+env:
+  PUBLISH_OWNER: ${{ inputs.owner || github.repository_owner }}
+  PUBLISH_REPO: ${{ inputs.repo || github.event.repository.name }}
+  # A tag pushed here publishes on its own; a caller has to ask for it.
+  PUBLISH_ENABLED: ${{ github.event_name == 'push' || inputs.publish }}
 
 jobs:
   publish-desktop:
@@ -56,13 +97,30 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           if [[ "$VERSION" == *-* ]]; then RELEASE_TYPE=prerelease; else RELEASE_TYPE=release; fi
+          if [ "$PUBLISH_ENABLED" = "true" ]; then PUBLISH_MODE=always; else PUBLISH_MODE=never; fi
           echo "tag=$GITHUB_REF_NAME version=$VERSION releaseType=$RELEASE_TYPE"
+          echo "target=$PUBLISH_OWNER/$PUBLISH_REPO publish=$PUBLISH_MODE"
           pnpm -C electron exec electron-builder --config electron-builder.yml \
             -c.extraMetadata.version="$VERSION" \
             -c.publish.releaseType="$RELEASE_TYPE" \
-            --publish always
+            -c.publish.owner="$PUBLISH_OWNER" \
+            -c.publish.repo="$PUBLISH_REPO" \
+            --publish "$PUBLISH_MODE"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PUBLISH_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Verify the built installer names match the docs
+        # On a dry run nothing is uploaded, so check the local build output instead;
+        # publish-sbom repeats this against the published assets when there are any.
+        if: ${{ env.PUBLISH_ENABLED != 'true' }}
+        shell: bash
+        run: |
+          cd electron/dist-electron
+          ls -1
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            ls -1 ./*Setup*.exe >/dev/null 2>&1 || { echo "no Setup .exe was built"; exit 1; }
+          else
+            ls -1 ./*.dmg >/dev/null 2>&1 || { echo "no .dmg was built"; exit 1; }
+          fi
 
   publish-pypi:
     name: Publish to PyPI
@@ -91,6 +149,9 @@ jobs:
           python -m pip install --require-hashes -r .github/requirements/build.txt
           python -m build
       - name: Publish to PyPI
+        # A dry run stops here: the sdist and wheel are built and kept as proof the
+        # packaging still works, and nothing is uploaded.
+        if: ${{ env.PUBLISH_ENABLED == 'true' }}
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           attestations: true # Attach PEP 740 provenance
@@ -98,6 +159,8 @@ jobs:
   publish-sbom:
     name: Attach SBOM to release
     needs: publish-desktop # Attach assets after the release is created
+    # Nothing to attach to on a dry run, which creates no release.
+    if: ${{ github.event_name == 'push' || inputs.publish }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # Upload assets to the release
@@ -112,14 +175,16 @@ jobs:
       - name: Attach SBOM to the release
         # Avoid injection by taking github.ref_name from the built-in env instead of interpolating it directly into the shell.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "$GITHUB_REF_NAME" "onot-${GITHUB_REF_NAME}-sbom.cdx.json" --clobber
+          GH_TOKEN: ${{ secrets.PUBLISH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" "onot-${GITHUB_REF_NAME}-sbom.cdx.json" \
+            --repo "$PUBLISH_OWNER/$PUBLISH_REPO" --clobber
       - name: Verify published installer names match the docs
         # Users download these exact asset names; the docs promise onot-Setup-x.y.z.exe and a .dmg.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PUBLISH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
-          names=$(gh release view "$GITHUB_REF_NAME" --json assets -q '.assets[].name')
+          names=$(gh release view "$GITHUB_REF_NAME" --repo "$PUBLISH_OWNER/$PUBLISH_REPO" --json assets -q '.assets[].name')
           echo "$names"
           echo "$names" | grep -Eq '^onot-Setup-[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?\.exe$' \
             || { echo "missing a published onot-Setup-x.y.z.exe asset"; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,10 @@ permissions:
 env:
   PUBLISH_OWNER: ${{ inputs.owner || github.repository_owner }}
   PUBLISH_REPO: ${{ inputs.repo || github.event.repository.name }}
-  # A tag pushed here publishes on its own; a caller has to ask for it.
-  PUBLISH_ENABLED: ${{ github.event_name == 'push' || inputs.publish }}
+  # A tag pushed here publishes on its own; a caller has to ask for it. The test
+  # is the ref, not the event name: a called workflow inherits the caller's event,
+  # so a dry run off a branch also arrives as a push.
+  PUBLISH_ENABLED: ${{ startsWith(github.ref, 'refs/tags/') || inputs.publish }}
   # The tag names the version. A dry run triggered off a branch has no tag in
   # its ref, so a caller passes the version it means to rehearse.
   RELEASE_TAG: ${{ inputs.version || github.ref_name }}
@@ -168,7 +170,7 @@ jobs:
     name: Attach SBOM to release
     needs: publish-desktop # Attach assets after the release is created
     # Nothing to attach to on a dry run, which creates no release.
-    if: ${{ github.event_name == 'push' || inputs.publish }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') || inputs.publish }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # Upload assets to the release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,11 @@ on:
         required: false
         type: boolean
         default: false
+      version:
+        description: "Tag to build, e.g. v1.2.3 (default: the pushed ref, which a dry run off a branch cannot supply)"
+        required: false
+        type: string
+        default: ""
     secrets:
       PUBLISH_TOKEN:
         description: "Token with contents:write on the target repository (default: the run GITHUB_TOKEN)"
@@ -55,6 +60,9 @@ env:
   PUBLISH_REPO: ${{ inputs.repo || github.event.repository.name }}
   # A tag pushed here publishes on its own; a caller has to ask for it.
   PUBLISH_ENABLED: ${{ github.event_name == 'push' || inputs.publish }}
+  # The tag names the version. A dry run triggered off a branch has no tag in
+  # its ref, so a caller passes the version it means to rehearse.
+  RELEASE_TAG: ${{ inputs.version || github.ref_name }}
 
 jobs:
   publish-desktop:
@@ -95,10 +103,10 @@ jobs:
       - name: build & publish to GitHub Releases
         shell: bash
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
           if [[ "$VERSION" == *-* ]]; then RELEASE_TYPE=prerelease; else RELEASE_TYPE=release; fi
           if [ "$PUBLISH_ENABLED" = "true" ]; then PUBLISH_MODE=always; else PUBLISH_MODE=never; fi
-          echo "tag=$GITHUB_REF_NAME version=$VERSION releaseType=$RELEASE_TYPE"
+          echo "tag=$RELEASE_TAG version=$VERSION releaseType=$RELEASE_TYPE"
           echo "target=$PUBLISH_OWNER/$PUBLISH_REPO publish=$PUBLISH_MODE"
           pnpm -C electron exec electron-builder --config electron-builder.yml \
             -c.extraMetadata.version="$VERSION" \
@@ -126,7 +134,7 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     # Publish only final release tags (hyphenated tags like rc/beta are desktop-only).
-    if: ${{ !contains(github.ref_name, '-') }}
+    if: ${{ !contains(inputs.version || github.ref_name, '-') }}
     permissions:
       id-token: write # OIDC Trusted Publishing
       contents: read
@@ -141,8 +149,8 @@ jobs:
       - name: Pin package version to the git tag
         # Treat the tag as the single source of truth to align sdist/wheel versions (ignore pyproject's .dev0).
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          echo "Building onot $VERSION from tag $GITHUB_REF_NAME"
+          VERSION="${RELEASE_TAG#v}"
+          echo "Building onot $VERSION from tag $RELEASE_TAG"
           sed -i -E "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
       - name: Build sdist and wheel
         run: |
@@ -171,20 +179,20 @@ jobs:
         with:
           path: .
           format: cyclonedx-json
-          output-file: onot-${{ github.ref_name }}-sbom.cdx.json
+          output-file: onot-${{ inputs.version || github.ref_name }}-sbom.cdx.json
       - name: Attach SBOM to the release
         # Avoid injection by taking github.ref_name from the built-in env instead of interpolating it directly into the shell.
         env:
           GH_TOKEN: ${{ secrets.PUBLISH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "$GITHUB_REF_NAME" "onot-${GITHUB_REF_NAME}-sbom.cdx.json" \
+          gh release upload "$RELEASE_TAG" "onot-${RELEASE_TAG}-sbom.cdx.json" \
             --repo "$PUBLISH_OWNER/$PUBLISH_REPO" --clobber
       - name: Verify published installer names match the docs
         # Users download these exact asset names; the docs promise onot-Setup-x.y.z.exe and a .dmg.
         env:
           GH_TOKEN: ${{ secrets.PUBLISH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
-          names=$(gh release view "$GITHUB_REF_NAME" --repo "$PUBLISH_OWNER/$PUBLISH_REPO" --json assets -q '.assets[].name')
+          names=$(gh release view "$RELEASE_TAG" --repo "$PUBLISH_OWNER/$PUBLISH_REPO" --json assets -q '.assets[].name')
           echo "$names"
           echo "$names" | grep -Eq '^onot-Setup-[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?\.exe$' \
             || { echo "missing a published onot-Setup-x.y.z.exe asset"; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,11 @@ name: release
 # Without it, and without `publish`, the installers are still built and their names
 # verified, and nothing reaches the release.
 #
-# A caller is a separate entry point for PyPI's OIDC check: the `workflow` claim names
-# the caller's file, not this one, so the calling repository needs its own trusted
-# publisher entry on PyPI.
+# PyPI is the one part a caller cannot inherit. Trusted Publishing identifies the
+# workflow by the entry point, so a call from elsewhere does not match the publisher
+# registered for this repository. A caller passes PYPI_TOKEN instead and gives up the
+# PEP 740 provenance that only a Trusted Publishing upload carries; a tag pushed here
+# still publishes token-lessly with provenance.
 on:
   push:
     tags: ["v*"]
@@ -50,6 +52,9 @@ on:
     secrets:
       PUBLISH_TOKEN:
         description: "Token with contents:write on the target repository (default: the run GITHUB_TOKEN)"
+        required: false
+      PYPI_TOKEN:
+        description: "PyPI API token; leave unset to authenticate through Trusted Publishing instead"
         required: false
 
 permissions:
@@ -164,7 +169,13 @@ jobs:
         if: ${{ env.PUBLISH_ENABLED == 'true' }}
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
-          attestations: true # Attach PEP 740 provenance
+          # An empty password makes the action fall back to Trusted Publishing, which
+          # is how a tag pushed to this repository authenticates. A caller running
+          # elsewhere cannot use that identity and passes a token instead.
+          password: ${{ secrets.PYPI_TOKEN }}
+          # PEP 740 provenance is only issued for a Trusted Publishing upload, so it
+          # follows whichever way this run authenticated.
+          attestations: ${{ secrets.PYPI_TOKEN == '' }}
 
   publish-sbom:
     name: Attach SBOM to release


### PR DESCRIPTION
Actions cannot run here while billing is blocked, so a release cannot be built in this repository. This lets a fork run the build on its own runners while the assets still land here.

`workflow_call` takes `owner`/`repo` to retarget the GitHub Release, `version` to name the tag, `publish` to gate the upload, and optional `PUBLISH_TOKEN`/`PYPI_TOKEN` secrets. Every input is optional and defaults to current behaviour, so a tag pushed here publishes exactly as before, token-lessly and with PEP 740 provenance.

Two things needed care:

- A called workflow inherits the caller's `github.event_name`, so a branch-driven rehearsal also arrives as a push. Publishing is decided from `github.ref` instead, the same way bomlens does it.
- Trusted Publishing identifies a workflow by its entry point, so an upload starting in a fork never matches the publisher registered for this repository. The job accepts a PyPI token for that path and ties `attestations` to which credential was used, rather than asking for provenance the upload cannot issue.

Verified twice on haksungjang/onot (branch `ci/publish-dry-run`, calling this branch). The second run: both `publish-desktop` legs green on Windows and macOS, the PyPI job building sdist and wheel and stopping before upload, the SBOM job skipped. Nothing was written -- the v1.1.2 assets here still carry their 2026-07-02 timestamps and the fork has no releases.

The build definition is called rather than copied, so the fork carries no second copy to drift.