### PR TITLE
ci(release): create the release before electron-builder uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,26 @@ jobs:
       # the pushed tag and injected via extraMetadata.version to align the release tag
       # and filenames. If the tag contains '-' (rc/beta, etc.) it is published as a
       # prerelease; otherwise it is published as a public release.
+      - name: Ensure the release exists before uploading
+        # electron-builder uploads the artifacts of one leg in parallel, and each
+        # upload creates the release when it finds none, so two of them race and the
+        # loser gets a 422 already_exists. (max-parallel above only serializes the OS
+        # legs, which is a different race.) Creating it up front leaves nothing to
+        # race over, and an existing release is left as it is so the second leg and a
+        # re-run both just add their assets.
+        if: ${{ env.PUBLISH_ENABLED == 'true' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.PUBLISH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          target="$PUBLISH_OWNER/$PUBLISH_REPO"
+          if gh release view "$RELEASE_TAG" --repo "$target" >/dev/null 2>&1; then
+            echo "release $RELEASE_TAG already exists on $target"
+            exit 0
+          fi
+          if [[ "$RELEASE_TAG" == *-* ]]; then pre=(--prerelease); else pre=(); fi
+          gh release create "$RELEASE_TAG" --repo "$target" \
+            --title "${RELEASE_TAG#v}" --generate-notes "${pre[@]}"
       - name: build & publish to GitHub Releases
         shell: bash
         run: |


### PR DESCRIPTION
electron-builder uploads a leg's artifacts in parallel and each upload creates the release when it finds none. On v1.1.3-rc1 the installer and its blockmap both decided the release was missing 3ms apart, so one created it and the other failed with `422 already_exists`, leaving the release without `latest.yml` and the blockmap.

```
14:15:18.597  uploading  file=onot-Setup-1.1.3-rc1.exe.blockmap
14:15:18.600  uploading  file=onot-Setup-1.1.3-rc1.exe
14:15:19.012  creating GitHub release  reason=release doesn't exist
14:15:19.015  creating GitHub release  reason=release doesn't exist
```

`max-parallel: 1` does not cover this. It serializes the OS legs, and this race is between two files inside one leg. The legs were correctly serialized on that run (Windows 14:10-14:15, macOS from 14:15:40), so this is a separate fault that a tag pushed to this repository would have hit too.

Creating the release up front leaves nothing to race over. An existing release is left alone, so the second leg and a re-run of a partial upload both just add their assets.

Verified with v1.1.3-rc2 through haksungjang/onot: both desktop legs green and all seven assets present (`latest.yml`, `latest-mac.yml`, the .dmg and .exe with their blockmaps, and the SBOM). `Attach SBOM to release` ran for the first time and its asset-name check passed. PyPI stayed skipped, as a hyphenated tag should.

v1.1.3-rc1 and -rc2 are test prereleases and can be deleted.