### PR TITLE
docs: record how CI and releases work while Actions is unavailable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,21 @@ CI runs the same checks on Linux, macOS, and Windows across Python 3.11–3.13, 
 SAST (CodeQL, Semgrep), SCA (SBOM + grype), and secret scanning. All checks must
 pass before a PR can be merged.
 
+### While Actions is unavailable here
+
+GitHub Actions currently cannot start on this repository. Every workflow fails
+within seconds without running a single step, so a red check on your PR is not a
+verdict on your change. The branch protection rules that required those checks have
+been lifted for now and will be restored once Actions works again.
+
+Maintainers verify changes on a fork in the meantime — `haksungjang/onot`, which runs
+the same `ci` and `security` workflows on its own runners. Nothing in them depends on
+organization secrets, so the results carry over. If you are working on a fork of your
+own, enable Actions there and the checks will run on your branches.
+
+Please still run the checks above locally before opening a PR; that is what the
+review leans on right now.
+
 ## Pull request guidelines
 
 - **Branch** off `main` (e.g. `feat/...`, `fix/...`, `chore/...`, `docs/...`).
@@ -85,6 +100,37 @@ Releases are tag-driven. Pushing a `v*` tag triggers `.github/workflows/release.
 PyPI publishing uses **token-less Trusted Publishing (OIDC)**. One-time setup on
 PyPI: add a trusted publisher for this project with owner `sktelecom`, repository
 `onot`, workflow `release.yml`, and environment `pypi`.
+
+### Releasing while Actions is unavailable here
+
+A tag pushed to this repository currently builds nothing, so the release runs on the
+`haksungjang/onot` fork instead and uploads the assets back here. `release.yml`
+accepts a `workflow_call` for exactly this: `owner`/`repo` retarget the GitHub
+Release, `version` names the tag, `publish` gates the upload, and `PUBLISH_TOKEN`
+carries write access to this repository. The fork holds only a thin caller
+(`publish-upstream-release.yml` on its `ci/publish-dry-run` branch) that calls this
+workflow at `@main`, so there is no second copy of the build to drift.
+
+1. Bump the versions and add the `CHANGELOG.md` entry as above, and merge to `main`.
+2. Sync the fork's `main` with this repository.
+3. Run the caller from the fork, naming the tag:
+
+   ```bash
+   gh workflow run publish-upstream-release.yml --repo haksungjang/onot \
+     --ref ci/publish-dry-run -f version=v1.2.0 -f publish=true
+   ```
+
+Do not push a `v*` tag here while this lasts. It only leaves a failed run. The tag is
+created by the release itself.
+
+Pushing to the fork's `ci/publish-dry-run` branch rehearses the same build without
+uploading anything, which is the way to check a change to the release path.
+
+One thing does not carry over: Trusted Publishing identifies a workflow by its entry
+point, so an upload starting on the fork never matches the publisher registered here.
+That path authenticates with a PyPI API token and gives up the PEP 740 provenance
+that only a Trusted Publishing upload carries. Once Actions works here again, a tag
+pushed to this repository publishes token-lessly with provenance, as described above.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,10 +124,16 @@ Do not push a `v*` tag here while this lasts. It only leaves a failed run. The t
 created by the release itself.
 
 **A security fix does not take this path until its advisory is published.** Step 2
-syncs a public fork, and that is the moment the patch becomes readable by anyone.
-Develop the fix in the temporary private fork GitHub creates alongside the draft
-advisory, merge it here when the advisory goes public, and sync and release only
-after that. The order is what keeps the fix private, not the repository it sits in.
+syncs a public fork, which would hand the patch to everyone watching it. Develop the
+fix in the temporary private fork GitHub creates alongside the draft advisory and
+merge that fork's PR when the fix is ready. That merge lands the patch on `main`
+here, and it is a precondition for publishing: GitHub will not publish an advisory
+while a PR is still open on the temporary fork. Publish, then sync the fork and
+release.
+
+So the patch does sit on a public branch for the few minutes between the merge and
+the publication, and GitHub's flow offers no way around it. Publish as soon as the
+merge lands and keep that window short.
 
 Pushing to the fork's `ci/publish-dry-run` branch rehearses the same build without
 uploading anything, which is the way to check a change to the release path.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,12 @@ workflow at `@main`, so there is no second copy of the build to drift.
 Do not push a `v*` tag here while this lasts. It only leaves a failed run. The tag is
 created by the release itself.
 
+**A security fix does not take this path until its advisory is published.** Step 2
+syncs a public fork, and that is the moment the patch becomes readable by anyone.
+Develop the fix in the temporary private fork GitHub creates alongside the draft
+advisory, merge it here when the advisory goes public, and sync and release only
+after that. The order is what keeps the fix private, not the repository it sits in.
+
 Pushing to the fork's `ci/publish-dry-run` branch rehearses the same build without
 uploading anything, which is the way to check a change to the release path.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,8 +35,9 @@ Please include:
 - We aim to acknowledge a report within **5 business days**.
 - We will keep you informed as we investigate and prepare a fix.
 - The fix is developed in the temporary private fork GitHub creates alongside the
-  draft advisory. Nothing reaches a public repository, branch, or release until the
-  advisory is published, so the fix and the disclosure land together.
+  draft advisory, out of public view. Merging that fork is what lets the advisory be
+  published, so the patch reaches the public default branch a few minutes ahead of
+  the advisory itself. We publish as soon as the merge lands to keep that gap short.
 - Once a fix is released, we will credit you in the advisory unless you prefer to
   remain anonymous.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,9 @@ Please include:
 
 - We aim to acknowledge a report within **5 business days**.
 - We will keep you informed as we investigate and prepare a fix.
+- The fix is developed in the temporary private fork GitHub creates alongside the
+  draft advisory. Nothing reaches a public repository, branch, or release until the
+  advisory is published, so the fix and the disclosure land together.
 - Once a fix is released, we will credit you in the advisory unless you prefer to
   remain anonymous.
 


### PR DESCRIPTION
Actions cannot start on this repository, so a PR's red checks say nothing about the change and a `v*` tag builds nothing. Neither is visible from the outside, and the workaround lives on a fork a contributor has no reason to know about.

`CONTRIBUTING.md` gets two sections:

- Under **Running checks**, what a contributor should make of the failing checks: the workflows fail in seconds without running a step, the required-check rules are lifted for now, maintainers verify on `haksungjang/onot`, and local checks are what the review leans on.
- Under **Releasing (maintainers)**, the release path through the fork: the `workflow_call` interface, the order from merge to dispatch, the command, and a warning not to push a `v*` tag here (the release creates the tag). It also records the one thing the fork path cannot carry over -- Trusted Publishing identifies a workflow by its entry point, so that path authenticates with a token and gives up PEP 740 provenance.

A security fix must not take that path before its advisory is published: step 2 syncs a public fork, which is the moment the patch becomes readable. The exception sits next to the step rather than only in the security policy, because that is where someone following the procedure will be looking. `SECURITY.md` gains the reporter-facing half -- the fix is developed in the temporary private fork beside the draft advisory, and nothing reaches a public repository until the advisory is published.

Both sections are scoped to the outage and come out when Actions works here again. Advisory handling as a general procedure is deliberately left out; it applies regardless of Actions and belongs in a document that outlives this one.

Verified on haksungjang/onot#4: `ci` and `security` both green.