### PR TITLE
chore(release): sync 1.1.3 across __init__ and package manifests

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onot-desktop",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "packageManager": "pnpm@10.34.4",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onot-frontend",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.3",
   "packageManager": "pnpm@10.34.4",
   "type": "module",
   "scripts": {

--- a/src/onot/__init__.py
+++ b/src/onot/__init__.py
@@ -3,4 +3,4 @@
 
 """onot — open source software notice generator from SBOM/SPDX documents."""
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"


### PR DESCRIPTION
The 1.1.3 security release (GHSA-qcgh-vq3j-cm8w) bumped pyproject.toml but left src/onot/__init__.py, frontend/package.json, and electron/package.json at 1.1.2. Without this, onot.__version__ and the desktop app version would ship as 1.1.2. Aligns all four to 1.1.3 before the release is built.