### PR TITLE
docs: write down the security advisory procedure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,8 @@ release.
 
 So the patch does sit on a public branch for the few minutes between the merge and
 the publication, and GitHub's flow offers no way around it. Publish as soon as the
-merge lands and keep that window short.
+merge lands and keep that window short. The full procedure, with the commands, is in
+[docs/SECURITY_ADVISORY_PROCESS.md](docs/SECURITY_ADVISORY_PROCESS.md).
 
 Pushing to the fork's `ci/publish-dry-run` branch rehearses the same build without
 uploading anything, which is the way to check a change to the release path.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,8 @@ Please include:
   draft advisory, out of public view. Merging that fork is what lets the advisory be
   published, so the patch reaches the public default branch a few minutes ahead of
   the advisory itself. We publish as soon as the merge lands to keep that gap short.
+  The steps we follow are written down in
+  [docs/SECURITY_ADVISORY_PROCESS.md](docs/SECURITY_ADVISORY_PROCESS.md).
 - Once a fix is released, we will credit you in the advisory unless you prefer to
   remain anonymous.
 

--- a/docs/SECURITY_ADVISORY_PROCESS.md
+++ b/docs/SECURITY_ADVISORY_PROCESS.md
@@ -75,6 +75,10 @@ GHSA-qcgh-vq3j-cm8w the merge landed at 03:10:12Z and the advisory published at
 03:12:39Z, a gap of two and a half minutes. The window cannot be removed, only kept
 short, so publish as soon as the merge completes rather than moving on to other work.
 
+Settle the credits before you publish, not after. [SECURITY.md](../SECURITY.md)
+promises the reporter credit unless they asked to stay anonymous, and asking them
+which name to use takes a round trip you do not want to discover mid-merge.
+
 ## 5. Release
 
 From here the ordinary release process applies. Bump the versions, add the

--- a/docs/SECURITY_ADVISORY_PROCESS.md
+++ b/docs/SECURITY_ADVISORY_PROCESS.md
@@ -1,0 +1,87 @@
+# Handling a security advisory
+
+How a maintainer takes a reported vulnerability from a private report to a released
+fix. Reporters should read [SECURITY.md](../SECURITY.md) instead; this is the other
+side of that process.
+
+The order below is not a preference. GitHub's advisory tooling enforces most of it,
+and the two places where people get it wrong have opposite costs: publishing too late
+blocks nothing but leaves the fix sitting in the open, while syncing the public fork
+too early hands the patch to anyone watching it.
+
+Every command here was used on GHSA-qcgh-vq3j-cm8w, the first advisory this project
+handled end to end.
+
+## 1. Open a draft advisory
+
+```bash
+gh api --method POST repos/sktelecom/onot/security-advisories --input advisory.json
+```
+
+`advisory.json` carries `summary`, `description`, `cvss_vector_string`, `cwe_ids`, and
+`vulnerabilities`. The advisory is created in `draft` state and stays private until
+you publish it in step 4.
+
+A report that arrived through GitHub's private vulnerability reporting is already a
+draft advisory, so start from it rather than opening a second one.
+
+## 2. Create the temporary private fork
+
+```bash
+gh api --method POST repos/sktelecom/onot/security-advisories/<ghsa-id>/forks
+```
+
+The response's `full_name` is `sktelecom/onot-<ghsa-id>`. This fork is private and
+visible only to the advisory's collaborators. The web UI offers the same button, but
+the API works and keeps the whole process scriptable.
+
+## 3. Develop the fix in that fork
+
+Branch off **the temporary fork's `main`**, not off whatever you have checked out.
+That `main` mirrors this repository's `main`, so a branch based on anything else drags
+unrelated files into the PR diff and makes the fix hard to review.
+
+```bash
+git remote add advisory https://github.com/sktelecom/onot-<ghsa-id>.git
+git fetch advisory
+git checkout -b fix/<slug> advisory/main
+# write the fix, or cherry-pick it if you prototyped elsewhere
+git push advisory fix/<slug>
+gh api --method POST repos/sktelecom/onot-<ghsa-id>/pulls \
+  -f base=main -f head=fix/<slug> -f title='fix: ...'
+```
+
+CI does not run on this fork. It belongs to the organization and is covered by the
+same Actions outage described in [CONTRIBUTING.md](../CONTRIBUTING.md), and the public
+fork used for normal verification is no help here because pushing the patch there
+would disclose it. Verify locally instead: the checks under **Running checks**, plus a
+reproduction of the reported behavior before and after the patch.
+
+Keep the PR to the fix and its tests. Version bumps and the `CHANGELOG.md` entry go
+with the release in step 5, where they belong to a version number that exists.
+
+## 4. Merge, then publish immediately
+
+Merging the temporary fork's PR lands the patch on **`sktelecom/onot`'s `main`**,
+directly. It does not go to the temporary fork's `main`, and there is no later step
+that moves it across.
+
+The merge is also a precondition for publishing: GitHub refuses to publish an advisory
+while a PR is still open on its temporary fork. So the sequence is merge first, then
+publish, and no amount of care reverses it.
+
+This means the patch sits on a public branch before the advisory exists. On
+GHSA-qcgh-vq3j-cm8w the merge landed at 03:10:12Z and the advisory published at
+03:12:39Z, a gap of two and a half minutes. The window cannot be removed, only kept
+short, so publish as soon as the merge completes rather than moving on to other work.
+
+## 5. Release
+
+From here the ordinary release process applies. Bump the versions, add the
+`CHANGELOG.md` entry, and follow **Releasing (maintainers)** in
+[CONTRIBUTING.md](../CONTRIBUTING.md).
+
+While Actions is unavailable on this repository the release runs from the public fork,
+and syncing that fork is what publishes the patch to a wide audience. Do not sync it
+before step 4 is complete. After publication the fix is disclosed anyway, so the
+normal path is safe again.


### PR DESCRIPTION
The first advisory this project handled end to end (GHSA-qcgh-vq3j-cm8w) turned up two things that are not guessable from the outside, and both cost something when guessed wrong.

Merging the temporary fork's PR lands the patch on this repository's `main` directly, and it is a precondition for publishing rather than a step that follows it -- GitHub refuses to publish while a PR is open on that fork. Anyone reasoning from the names would wait for a publication that cannot happen yet. It also means the patch sits on a public branch for the gap between the two; on that advisory it was 2m27s (merge 03:10:12Z, publication 03:12:39Z). The document says so rather than implying the fix stays private throughout.

Branching off anything other than the temporary fork's `main` drags unrelated files into the PR diff, because that `main` mirrors this repository while a working branch usually does not.

The procedure lives in `docs/` rather than in `CONTRIBUTING.md` because it applies regardless of the Actions outage, and the outage sections come out once Actions works here again. `SECURITY.md` and `CONTRIBUTING.md` both link to it.

Every command in it was used on GHSA-qcgh-vq3j-cm8w. Settling credits before publishing is added on top: `SECURITY.md` promises the reporter credit, and that round trip is worst discovered inside the window the document tells you to keep short.

Verified on haksungjang/onot#6: `security` green, `ci` green on the second attempt. The first attempt failed an unrelated flaky axe check (`color-contrast` on `.hover:bg-brand-hover` in the light theme) that passed on re-run.