### PR TITLE
feat: UI/UX phase 3 (notice navigation, CLI reporting, design notes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- HTML notices open with a table of contents and link both ways between a component and
+  the licence it falls under, with a way back to the top in a long notice. A notice with
+  hundreds of components could previously only be read by scrolling.
+- `onot init` writes a commented `onot.yaml`. The configuration schema existed only as
+  fields in the source.
+- `onot generate --json` reports the written files and the warnings as JSON, and
+  `--quiet` suppresses the warnings.
+- `docs/DESIGN.md` records the design tokens, the contrast bar CI enforces, and the traps
+  in the notice stylesheet and the preview frame that have already cost a fix each.
+
 - The window now opens straight away and says the local engine is starting, instead of
   leaving nothing on screen for up to 40 seconds on macOS and two minutes on Windows
   while the sidecar came up.
@@ -70,6 +80,11 @@ All notable changes to this project are documented here. The format is based on
 - The desktop PDF matches the one the CLI produces: same page size, margins and numbered
   footer. It previously ignored the print stylesheet entirely.
 - Quitting while the engine is still starting no longer hangs the app on a retry dialog.
+- Notices render in the intended sans-serif face. The theme stylesheet was HTML-escaped
+  into the document, and since `<style>` never decodes an entity, the quoted font names
+  broke the whole declaration and every notice fell back to the default serif.
+- Warnings now end with a count by kind, so a run over a large SBOM says what the hundreds
+  of lines amount to.
 
 ## [1.1.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,83 +8,78 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
-- HTML notices open with a table of contents and link both ways between a component and
-  the licence it falls under, with a way back to the top in a long notice. A notice with
-  hundreds of components could previously only be read by scrolling.
-- `onot init` writes a commented `onot.yaml`. The configuration schema existed only as
-  fields in the source.
-- `onot generate --json` reports the written files and the warnings as JSON, and
-  `--quiet` suppresses the warnings.
-- `docs/DESIGN.md` records the design tokens, the contrast bar CI enforces, and the traps
-  in the notice stylesheet and the preview frame that have already cost a fix each.
-
-- The window now opens straight away and says the local engine is starting, instead of
-  leaving nothing on screen for up to 40 seconds on macOS and two minutes on Windows
-  while the sidecar came up.
-- An application menu, replacing Electron's default. It carries Open SBOM and Save
-  Notice with their usual shortcuts, About, and links to the user guide, the release
-  notes and the issue tracker. Reload and the developer tools appear only in a
-  development build.
+- The desktop app follows the system theme and offers an explicit Light or Dark choice,
+  which it remembers. Light mode was written but unreachable before, because the app
+  pinned dark mode on the document element.
+- The window opens straight away and says the local engine is starting, instead of leaving
+  nothing on screen for up to 40 seconds on macOS and two minutes on Windows while the
+  sidecar came up.
+- An application menu, replacing Electron's default. It carries Open SBOM and Save Notice
+  with their usual shortcuts, About, and links to the user guide, the release notes, the
+  releases page and the issue tracker. Reload and the developer tools appear only in a
+  development build. Checking for updates opens a page: the app still contacts nothing on
+  its own.
 - The window remembers its size, position and maximised state, has a minimum size, and
   takes the name of the open file as its title.
 - Saving reports where the file went, with Show in folder.
-- The notice details can be remembered between runs, and the copyright holder, which the
-  API already accepted, is now on screen.
 - The parse summary breaks components down by license, and each warning is shown with a
   line saying what it means for the notice.
+- The notice details can be remembered between runs, and the copyright holder, which the
+  API already accepted, is now on screen.
 - The preview can be expanded to the height of the window.
+- HTML notices open with a table of contents and link both ways between a component and
+  the license it falls under, with a way back to the top in a long notice. A notice with
+  hundreds of components could previously only be read by scrolling.
+- `onot --version`, alongside the existing `onot version` subcommand.
+- `onot init` writes a commented `onot.yaml`. The configuration schema existed only as
+  fields in the source.
+- `onot generate --json` reports the written files and the warnings as JSON, and `--quiet`
+  suppresses the warnings.
+- Exit codes and worked examples in `onot --help` and the README, so the CLI can be wired
+  into a pipeline without reading the source.
+- `docs/DESIGN.md` records the design tokens, the contrast bar CI enforces, and the traps
+  in the notice stylesheet and the preview frame that have already cost a fix each.
 
 ### Changed
 
+- The brand colour moves from green to the indigo of the logo, so the logo, the app and the
+  generated notice share one colour. Colours, radii and spacing are now design tokens
+  rather than values repeated across components.
 - Saving a notice is the primary action. The primary button used to be Generate preview,
   which is a step on the way rather than the thing anyone came for.
 - Output formats read as HTML, Text, Markdown and PDF rather than as API identifiers.
 - The three parts of the screen are numbered, and Settings is now Notice details.
-- The user guide covers macOS as well as Windows, having been Windows-only.
-
-- The desktop app follows the system theme and offers an explicit Light or Dark
-  choice, which it remembers. Light mode was written but unreachable before, because
-  the app pinned dark mode on the document element.
-- `onot --version`, alongside the existing `onot version` subcommand.
-- Exit codes and worked examples in `onot --help` and the README, so the CLI can be
-  wired into a pipeline without reading the source.
-
-### Changed
-
-- The brand colour moves from green to the indigo of the logo, so the logo, the app
-  and the generated notice share one colour. Colours, radii and spacing are now
-  design tokens rather than values repeated across components.
-- All three text formats head a license with `Name (SPDX-Id)` and mark deprecated
-  ids. Previously the id appeared only in Markdown and the marker only in HTML.
+- All three text formats head a license with `Name (SPDX-Id)` and mark deprecated ids.
+  Previously the id appeared only in Markdown and the marker only in HTML.
 - Notices record the version of onot that produced them.
+- Warnings end with a count by kind, so a run over a large SBOM says what the hundreds of
+  lines amount to.
+- The user guide covers macOS as well as Windows, having been Windows-only.
 
 ### Fixed
 
 - The text notice now lists each component's copyright. It carried only the name and
-  license, while HTML and Markdown both carried a Copyright column, so a product
-  shipping the text notice alone omitted a notice that MIT and BSD style licenses
-  require to be retained.
-- Generated PDFs no longer waste pages. A keep-together rule was applied to license
-  blocks that run past a page, pushing each to a fresh page; on the SPDX sample this
-  cost two of seven pages.
-- The desktop app and the CLI now apply the same page rules when producing a PDF.
-- Accessibility: the primary button, the drop zone border, and the notice footer and
-  page numbers all meet WCAG AA contrast, where they measured 3.46:1, 1.9:1 and
-  3.54:1. The drop zone shows a focus indicator when reached by keyboard, having
-  shown none at all. Checkboxes follow the app's theme rather than the system's.
-  `prefers-reduced-motion` is honoured.
-- Saved notices carry the product name and a timestamp on every route. The desktop app
-  could not read the filename the API chose, because a cross-origin response hides
-  `Content-Disposition` unless the server exposes it, so every desktop save fell back to
-  a generic name.
-- The desktop PDF matches the one the CLI produces: same page size, margins and numbered
-  footer. It previously ignored the print stylesheet entirely.
-- Quitting while the engine is still starting no longer hangs the app on a retry dialog.
+  license, while HTML and Markdown both carried a Copyright column, so a product shipping
+  the text notice alone omitted a notice that MIT and BSD style licenses require to be
+  retained.
 - Notices render in the intended sans-serif face. The theme stylesheet was HTML-escaped
   into the document, and since `<style>` never decodes an entity, the quoted font names
   broke the whole declaration and every notice fell back to the default serif.
-- Warnings now end with a count by kind, so a run over a large SBOM says what the hundreds
-  of lines amount to.
+- Generated PDFs no longer waste pages. A keep-together rule was applied to license blocks
+  that run past a page, pushing each to a fresh page; on the SPDX sample this cost two of
+  seven pages.
+- The desktop PDF matches the one the CLI produces: same page size, margins and numbered
+  footer. It previously ignored the print stylesheet entirely.
+- Saved notices carry the product name and a timestamp on every route. The desktop app
+  could not read the filename the API chose, because a cross-origin response hides
+  `Content-Disposition` unless the server exposes it, so every desktop save fell back to a
+  generic name.
+- Accessibility: the primary button, the drop zone border, and the notice footer and page
+  numbers all meet WCAG AA contrast, where they measured 3.46:1, 1.9:1 and 3.54:1. The drop
+  zone shows a focus indicator when reached by keyboard, having shown none at all.
+  Checkboxes follow the app's theme rather than the system's. `prefers-reduced-motion` is
+  honoured.
+- Quitting while the engine is still starting no longer hangs the app on a retry dialog.
 
 ## [1.1.3]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ onot is a Python core with a React UI packaged as an installable desktop app.
 - `frontend/` — React + Vite UI (Vitest tests)
 - `electron/` — Electron desktop shell (Playwright E2E)
 - `tests/` — Python test suite
-- `docs/` — user guide and design/decision records (`docs/2.0/`)
+- `docs/` — user guide, design notes (`DESIGN.md`), and decision records (`docs/2.0/`)
 
 ## Development setup
 
@@ -79,6 +79,9 @@ review leans on right now.
   e.g. `feat(render): add Markdown table layout` or `fix(ingest): handle empty SPDX relationships`.
 - **Update docs** (`README.md`, `docs/USER_GUIDE.md`) when behavior changes, and add a
   `CHANGELOG.md` entry under `[Unreleased]`.
+- **Touching the UI or the notice theme?** Read [`docs/DESIGN.md`](docs/DESIGN.md) first. It
+  covers the design tokens, the contrast bar the CI enforces, and two traps in the notice
+  stylesheet that have already cost a release each.
 
 ## Reporting bugs and requesting features
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,24 @@ onot generate -i sbom.spdx.json -f html -f markdown --output-dir ./output
 #   --config      onot.yaml (company info, etc.)
 #   --online      fetch missing license texts remotely (offline by default)
 #   --stdout      write a single text format to stdout
+#   -q/--quiet    suppress warnings
+#   --json        report the written files and warnings as JSON
 
+onot init        # a commented onot.yaml to start from
 onot formats     # supported output formats
 onot --version   # or: onot version
+```
+
+Warnings go to stderr, each on its own line, followed by a count by kind. A large SBOM
+can produce hundreds, so `--quiet` drops them and `--json` puts the same information on
+stdout for a caller that has to act on it:
+
+```json
+{
+  "product": "example-product",
+  "written": [{ "format": "html", "path": "output/OSS_Notice_example-product_20260101_120000.html" }],
+  "warnings": ["no license information for foo 1.2.3"]
+}
 ```
 
 Input format is auto-detected by extension and content (including SPDX JSON vs.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,130 @@
+# Design notes
+
+How the desktop app and the generated notice are put together, so a change lands in the
+same shape as what is already there. The rules here are enforced where they can be: the
+axe check in `electron/e2e/a11y.e2e.mjs` measures contrast in the running app, in both
+themes, on every CI run.
+
+## Tokens
+
+Colours, radii and spacing are named in `frontend/src/index.css` and nowhere else.
+Components use the names, never a palette value:
+
+```jsx
+<p className="text-fg-muted">   // yes
+<p className="text-zinc-400">   // no
+```
+
+Each token carries its light and its dark value in a single `light-dark()` pair, so the
+two cannot drift apart:
+
+```css
+--onot-fg-muted: light-dark(#52525b, #a1a1aa);
+```
+
+`color-scheme` is the switch that chooses between them. It is left open on `:root`, which
+makes the app follow the operating system with no JavaScript and no chance of a wrong
+first paint; an explicit choice writes `data-theme="light"` or `"dark"`, which pins it.
+Because the same property drives the native controls, checkboxes and scrollbars follow the
+app rather than the OS. There is deliberately no `dark:` variant in the codebase, and no
+`darkMode` setting in the Tailwind config: a variant would only see part of this picture.
+
+| Token | Use |
+|--|--|
+| `surface` | the page |
+| `surface-raised` | cards and anything sitting on the page |
+| `surface-sunken` | hover fills, chips |
+| `fg` | body text |
+| `fg-muted` | labels, hints, secondary text |
+| `border` | dividers and decorative edges |
+| `border-strong` | control edges, which must clear 3:1 on their own |
+| `brand` / `on-brand` | the primary button fill and its text |
+| `brand-hover` | that button's hover fill |
+| `accent` | links, and the focus ring |
+| `danger-fg` / `danger-bg` / `danger-border` | the error banner |
+| `warning-fg` | warnings |
+| `success-fg` | confirmations |
+
+Radii come in two steps, `rounded-control` for buttons and inputs and `rounded-card` for
+cards. Spacing uses `2`, `3`, `4` and `6`. Type uses `text-xs` for secondary labels,
+`text-sm` for body and controls, `text-base` for card titles and `text-2xl` for the page
+title.
+
+## Colour and contrast
+
+Every text token clears 4.5:1 against the surface it is used on, and every control edge
+clears 3:1, in both themes. Two things are easy to miss when picking a value:
+
+- Hover states count. `brand-hover` in dark started as indigo-500 and measured 4.46:1
+  against white text, which the axe run caught and a palette review had not.
+- A control mid-transition reports a blended colour. That is a measurement artefact, not
+  a design fault, which is why the audit waits for controls to settle rather than
+  loosening the threshold.
+
+The brand colour is the indigo of the logo, `#4f46e5`. The app, the logo and the links in
+a generated notice all use it, and `notice.css` names its colours as variables for the
+same reason the app does.
+
+## Wording
+
+Format names are spelled the way a reader spells them: HTML, Text, Markdown, PDF, never
+the API's `html` or `pdf`. Buttons name what they do to something ("Save notice",
+"Preview"), and the primary button is the thing the user came for, not a step on the way.
+Every string lives in `frontend/src/lib/i18n.ts`; the notice's own strings live separately
+in `src/onot/rendering/i18n/en.yaml`, because one is the app and the other is the
+document.
+
+The project is English-only and CI enforces it (`scripts/check_no_hangul.py`). Prefer a
+plain hyphen to an em dash: terminals and PDF fonts handle it more predictably.
+
+## The generated notice
+
+`notice.css` is the whole theme. It is inlined into the HTML output, so a saved notice is
+one self-contained file.
+
+Its `@media print` block is the single source of the paged rules, because both routes to a
+PDF read it: WeasyPrint on the CLI, and Chromium's `printToPDF` in the desktop app.
+`pdf.css` adds only what is specific to WeasyPrint's paged media, the `@page` box and its
+numbered footer, and the desktop side passes matching margins and a footer template to
+`printToPDF`. When you change page geometry, change both or they drift.
+
+Two traps in this file have already been paid for:
+
+- Do not apply `page-break-inside: avoid` to a licence block. A full licence text runs past
+  a page, so the rule pushes each one to a fresh page and leaves the previous one half
+  empty.
+- The stylesheet is passed through the template with `| safe`. Autoescaping it turned every
+  quoted font name into `&#34;`, and because `<style>` is a raw-text element the entity is
+  never decoded, so the whole `font-family` declaration was invalid and notices rendered in
+  the default serif. Nothing else in the template may skip escaping.
+- An `@page` margin box does not inherit from `body`, which is why the font stack is a
+  variable that `pdf.css` reads rather than a value written once on `body`.
+
+## The preview
+
+The preview frame shows the same document the user is about to save, so the notice's own
+links have to work inside it. Four things have to hold at once, and each of them once did
+not:
+
+- The frame loads a **blob URL**, not `srcdoc`. An `about:srcdoc` document takes its base
+  URL from the parent, so a link to `#licenses` resolved against the app's URL and
+  navigated the frame to the app, leaving the preview blank.
+- The CSP allows `blob:` in `frame-src`.
+- The sandbox grants `allow-same-origin`. A fully opaque origin refuses the document's own
+  anchor links, which leaves the contents list looking fine and doing nothing. It must
+  never also grant `allow-scripts`: that pairing lets a frame lift its own sandbox. With
+  scripts withheld nothing in the notice executes, which is the actual protection.
+- `will-navigate` in the main process lets a subframe move within a `blob:` URL.
+
+`electron/e2e/preview-navigation.e2e.mjs` asserts the outcome rather than any one of these,
+because a regression in any of them looks identical from the user's side.
+
+## Checks
+
+- `bash scripts/gate.sh` runs the lot.
+- `electron/e2e/a11y.e2e.mjs` audits the running window with axe in both themes, checks
+  that the drop zone shows a focus indicator under keyboard navigation, and checks that
+  `prefers-reduced-motion` collapses the transitions.
+- The jsdom unit tests disable axe's `color-contrast` rule on purpose: jsdom has no
+  rendered colours, so the rule is silently skipped rather than checked. That coverage is
+  the E2E's job.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -125,5 +125,10 @@ Can I use it in an environment without internet?
 Is my SBOM file sent anywhere?
 : No. Parsing and notice generation all happen on your machine.
 
+How do I know when there is a newer version?
+: The app never contacts anything on its own, so it cannot tell you. Help then
+  **Check for Updates** opens the releases page in your browser, and Help then **About onot**
+  names the version you have, so you can compare the two.
+
 Can I use the command line (CLI) or build from source?
 : Yes. See the CLI and developer sections in the [README](../README.md).

--- a/electron/e2e/preview-navigation.e2e.mjs
+++ b/electron/e2e/preview-navigation.e2e.mjs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// The notice's own navigation has to work inside the preview, and getting there took four
+// things lining up: a blob: URL rather than srcdoc (an about:srcdoc document takes its base URL
+// from the parent, so "#licenses" navigated the frame to the app and blanked the preview),
+// blob: in the CSP frame-src, allow-same-origin on the sandbox (a fully opaque origin refuses
+// its own anchor links), and a will-navigate rule that lets a subframe move within a blob URL.
+// Any one of those regressing leaves a table of contents that looks fine and does nothing, so
+// this asserts the outcome rather than any single mechanism.
+import { expect, test } from "@playwright/test";
+import { launchApp, spdxFixture, uploadAndWaitParse } from "./_helpers.mjs";
+
+async function openPreview(window) {
+  await uploadAndWaitParse(window, spdxFixture);
+  await window.getByTestId("generate-preview").click();
+  await expect(window.locator("iframe")).toBeVisible({ timeout: 30000 });
+  return window.frameLocator("iframe");
+}
+
+function positions(frame) {
+  return frame.locator("html").evaluate((el) => {
+    const doc = el.ownerDocument;
+    const top = (id) => Math.round(doc.getElementById(id)?.getBoundingClientRect().top ?? NaN);
+    return {
+      scrollTop: Math.round(doc.scrollingElement.scrollTop),
+      headings: doc.querySelectorAll("h2").length,
+      viewport: Math.round(doc.scrollingElement.clientHeight),
+      licenses: top("licenses"),
+      offer: top("offer"),
+    };
+  });
+}
+
+test("the contents links move the preview, and leave it intact", async () => {
+  const { app, window } = await launchApp();
+  try {
+    const frame = await openPreview(window);
+    const before = await positions(frame);
+    expect(before.scrollTop).toBe(0);
+    expect(before.headings).toBeGreaterThan(0);
+
+    // In view, rather than pinned to the very top: the last section cannot reach the top
+    // because there is not enough document below it to scroll past.
+    const inView = async (key) => {
+      const at = await positions(frame);
+      return at[key] >= 0 && at[key] < at.viewport;
+    };
+
+    await frame.locator('nav.toc a[href="#licenses"]').click();
+    await expect.poll(() => inView("licenses"), { timeout: 5000 }).toBe(true);
+
+    await frame.locator('nav.toc a[href="#offer"]').click();
+    await expect.poll(() => inView("offer"), { timeout: 5000 }).toBe(true);
+    expect((await positions(frame)).scrollTop).toBeGreaterThan(before.scrollTop);
+
+    // Still the notice, not the app: srcdoc used to navigate the frame away entirely.
+    const after = await positions(frame);
+    expect(after.headings).toBe(before.headings);
+  } finally {
+    await app.close();
+  }
+});
+
+test("a licence links back to the component that uses it", async () => {
+  const { app, window } = await launchApp();
+  try {
+    const frame = await openPreview(window);
+    const href = await frame.locator(".license .used-by a").first().getAttribute("href");
+    expect(href).toMatch(/^#pkg-/);
+
+    await frame.locator(".license .used-by a").first().click();
+    await expect
+      .poll(
+        () =>
+          frame
+            .locator("html")
+            .evaluate(
+              (el, id) =>
+                Math.round(el.ownerDocument.getElementById(id).getBoundingClientRect().top),
+              href.slice(1),
+            ),
+        { timeout: 5000 },
+      )
+      .toBeLessThanOrEqual(1);
+  } finally {
+    await app.close();
+  }
+});
+
+test("the notice cannot run script in the preview", async () => {
+  const { app, window } = await launchApp();
+  try {
+    await openPreview(window);
+    const sandbox = await window.locator("iframe").getAttribute("sandbox");
+    // allow-same-origin is needed for the anchors; allow-scripts must never join it, because
+    // together they let a frame lift its own sandbox.
+    expect(sandbox).toBe("allow-same-origin");
+  } finally {
+    await app.close();
+  }
+});

--- a/electron/lib/menu-template.mjs
+++ b/electron/lib/menu-template.mjs
@@ -8,7 +8,9 @@ const REPO = "https://github.com/sktelecom/onot";
 export const LINKS = {
   userGuide: `${REPO}/blob/main/docs/USER_GUIDE.md`,
   issues: `${REPO}/issues/new`,
-  releases: `${REPO}/releases/latest`,
+  // The newest release, for comparing against the version in About.
+  latestRelease: `${REPO}/releases/latest`,
+  changelog: `${REPO}/blob/main/CHANGELOG.md`,
 };
 
 /**
@@ -33,8 +35,12 @@ export function buildMenuTemplate({
     role: "help",
     submenu: [
       { label: "User Guide", click: () => openExternal(LINKS.userGuide) },
-      { label: "Release Notes", click: () => openExternal(LINKS.releases) },
+      { label: "Release Notes", click: () => openExternal(LINKS.changelog) },
       { type: "separator" },
+      // Opens the releases page in a browser rather than querying an API. onot's promise is
+      // that it works offline and reaches nothing on its own, and a version check is not
+      // worth spending that; About names the version installed, for comparison.
+      { label: "Check for Updates...", click: () => openExternal(LINKS.latestRelease) },
       { label: "Report an Issue", click: () => openExternal(LINKS.issues) },
       ...(isMac ? [] : [{ type: "separator" }, about]),
     ],

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -64,7 +64,11 @@ function hardenWebContents(contents) {
     if (url.startsWith("http:") || url.startsWith("https:")) shell.openExternal(url);
     return { action: "deny" };
   });
-  contents.on("will-navigate", (event, url) => {
+  contents.on("will-navigate", (event, url, _isInPlace, isMainFrame) => {
+    // The notice preview is a blob: document in a sandboxed subframe, built by the renderer
+    // itself. Its own anchor links are navigations within that frame, and blocking them left
+    // the table of contents inert with no error to show for it.
+    if (!isMainFrame && url.startsWith("blob:")) return;
     if (!url.startsWith(appOrigin)) {
       event.preventDefault();
       if (url.startsWith("http:") || url.startsWith("https:")) shell.openExternal(url);
@@ -231,7 +235,11 @@ app.whenReady().then(async () => {
       responseHeaders: {
         ...details.responseHeaders,
         "Content-Security-Policy": [
-          "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://127.0.0.1:* http://localhost:*; frame-src 'self'",
+          // frame-src allows blob: for the notice preview, which the renderer builds itself
+          // from the sidecar's response and loads into a sandbox="" frame. srcdoc cannot be
+          // used there: it takes its base URL from the parent, so the notice's own anchor
+          // links would navigate the frame to the app.
+          "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://127.0.0.1:* http://localhost:*; frame-src 'self' blob:",
         ],
       },
     });

--- a/electron/test/menu.test.mjs
+++ b/electron/test/menu.test.mjs
@@ -53,12 +53,27 @@ test("File offers the two actions the app is for, with accelerators", () => {
 
 test("Help points at the documentation the app used to offer no route to", () => {
   const help = findSubmenu(buildMenuTemplate(options), "help");
-  assert.deepEqual(flatLabels(help).slice(0, 3), [
+  assert.deepEqual(flatLabels(help).slice(0, 4), [
     "User Guide",
     "Release Notes",
+    "Check for Updates...",
     "Report an Issue",
   ]);
   assert.match(LINKS.userGuide, /USER_GUIDE\.md$/);
+  assert.match(LINKS.changelog, /CHANGELOG\.md$/);
+});
+
+
+test("checking for updates opens a page rather than reaching out on its own", () => {
+  // The app advertises that it works offline and contacts nothing; a version check is not
+  // worth spending that, so the menu item hands the question to the browser.
+  const opened = [];
+  const template = buildMenuTemplate({ ...options, openExternal: (url) => opened.push(url) });
+  findSubmenu(template, "help")
+    .find((item) => item.label === "Check for Updates...")
+    .click();
+  assert.deepEqual(opened, [LINKS.latestRelease]);
+  assert.match(LINKS.latestRelease, /releases\/latest$/);
 });
 
 test("About sits in the app menu on macOS and under Help elsewhere", () => {

--- a/frontend/src/components/Preview.tsx
+++ b/frontend/src/components/Preview.tsx
@@ -2,16 +2,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Maximize2, Minimize2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { cn } from "../lib/cn";
 import { t, type UiLang } from "../lib/i18n";
 import { Button } from "./ui/Button";
 import { Card, CardTitle } from "./ui/Card";
 
+/**
+ * A blob URL, not srcdoc. An about:srcdoc document takes its base URL from the parent, so a
+ * link to "#licenses" in the notice resolves against the app's own URL: clicking one in the
+ * table of contents navigated the frame to the app and left the preview blank. A blob document
+ * has a URL of its own, so the same link scrolls, exactly as it does in the saved file.
+ */
+function useObjectUrl(html: string): string {
+  const [url, setUrl] = useState("");
+  useEffect(() => {
+    const objectUrl = URL.createObjectURL(new Blob([html], { type: "text/html" }));
+    setUrl(objectUrl);
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [html]);
+  return url;
+}
+
 export function Preview({ lang, html }: { lang: UiLang; html: string }) {
   // A real notice runs to hundreds of components, which is more than a fixed pane can show. The
   // expanded height is tied to the viewport so it fills whatever window the reader has.
   const [expanded, setExpanded] = useState(false);
+  const url = useObjectUrl(html);
   const title = t(lang, "preview");
 
   return (
@@ -33,12 +50,16 @@ export function Preview({ lang, html }: { lang: UiLang; html: string }) {
           {expanded ? t(lang, "collapse") : t(lang, "expand")}
         </Button>
       </div>
-      {/* Isolate the preview with iframe srcdoc + sandbox (prevents CSS conflicts/blocks scripts).
-          The frame keeps a white page in both themes because the notice is a light document. */}
+      {/* The sandbox withholds allow-scripts, so nothing in the notice can execute: no script,
+          no form, no navigation of the app around it. allow-same-origin is granted because a
+          fully opaque origin also refuses the notice's own anchor links, which left the table
+          of contents inert. The pairing to avoid is allow-same-origin with allow-scripts, where
+          a frame can lift its own sandbox; with scripts off there is nothing to lift it with.
+          The frame keeps a white page in both themes because a notice is a light document. */}
       <iframe
         title={title}
-        srcDoc={html}
-        sandbox=""
+        src={url}
+        sandbox="allow-same-origin"
         className={cn(
           "w-full rounded-control border border-border bg-white transition-[height]",
           expanded ? "h-[calc(100vh-12rem)]" : "h-[60vh]",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,7 +4,7 @@
 /* Design tokens.
    Utilities (bg-surface, text-fg-muted, border-border, …) resolve through the --onot-*
    variables below, so a theme switch only rewrites those variables. Components never name a
-   raw palette colour, which is what keeps light and dark in step. */
+   raw palette colour, which is what keeps light and dark in step. See docs/DESIGN.md. */
 @theme {
   --color-brand: var(--onot-brand);
   --color-brand-hover: var(--onot-brand-hover);

--- a/src/onot/cli/main.py
+++ b/src/onot/cli/main.py
@@ -8,12 +8,14 @@ generate (multiple formats, auto-detection, language, settings), formats, versio
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from pathlib import Path
 
 import typer
 
 from onot import __version__
+from onot.cli.warnings import summarize
 from onot.core.config import load_settings
 from onot.core.naming import output_filename
 from onot.core.writer import OutputWriter
@@ -33,6 +35,8 @@ Examples:
   onot generate -i sbom.spdx.json
   onot generate -i sbom.cdx.json -f html -f pdf -o ./notices
   onot generate -i sbom.xlsx -f text --stdout > NOTICE.txt
+  onot init                                  # a commented onot.yaml to start from
+  onot generate -i sbom.spdx.json --json     # machine-readable result and warnings
 
 \b
 Exit codes:
@@ -136,6 +140,12 @@ def generate(
     stdout: bool = typer.Option(
         False, "--stdout", help="Write a single non-binary format to stdout instead of a file."
     ),
+    quiet: bool = typer.Option(
+        False, "--quiet", "-q", help="Suppress warnings. Errors still print."
+    ),
+    as_json: bool = typer.Option(
+        False, "--json", help="Report the written files and the warnings as JSON on stdout."
+    ),
 ) -> None:
     """Generate an OSS notice from an SBOM."""
     formats = list(dict.fromkeys(formats))  # de-duplicate (preserve order)
@@ -157,13 +167,24 @@ def generate(
         typer.echo(f"error: {err}", err=True)
         raise typer.Exit(_exit_code(err)) from err
 
-    for warning in (*ingest_result.warnings, *resolve_result.warnings):
-        typer.echo(f"warning: {warning}", err=True)
+    warnings = [*ingest_result.warnings, *resolve_result.warnings]
+    # Warnings go to stderr as before. A large SBOM can emit hundreds of them, so a count by
+    # kind follows, which is what tells you whether they matter. --json carries the same
+    # information on stdout instead, for a caller that has to act on it.
+    if not quiet and not as_json:
+        for warning in warnings:
+            typer.secho(f"warning: {warning}", err=True, fg="yellow")
+        summary = summarize(warnings)
+        if summary:
+            typer.secho(summary, err=True, fg="yellow")
 
     doc = resolve_result.document
     now = datetime.now()
 
     if stdout:
+        if as_json:
+            typer.echo("error: --stdout and --json both write to stdout", err=True)
+            raise typer.Exit(1)
         if len(formats) != 1:
             typer.echo("error: --stdout requires exactly one --format", err=True)
             raise typer.Exit(1)
@@ -175,12 +196,65 @@ def generate(
         return
 
     writer = OutputWriter()
+    written: list[dict[str, str]] = []
     for fmt in formats:
         renderer = get_renderer(fmt, settings=settings)
         content = render(doc, fmt, settings=settings, now=now)
         filename = output_filename(doc.name, renderer.file_extension, now)
         path = writer.write(content, output_dir / filename)
-        typer.echo(f"wrote {path}")
+        written.append({"format": fmt, "path": str(path)})
+        if not as_json:
+            typer.echo(f"wrote {path}")
+
+    if as_json:
+        typer.echo(
+            json.dumps(
+                {"product": doc.name, "written": written, "warnings": warnings},
+                indent=2,
+            )
+        )
+
+
+# Every key is optional and every value here is a placeholder: the point is that a reader can
+# see the whole schema at once rather than going to read config.py for the field names.
+_CONFIG_TEMPLATE = """\
+# onot configuration. Pass it with: onot generate -i sbom.spdx.json --config onot.yaml
+# Every field is optional. Anything left out falls back to the SBOM's own creation info.
+
+company:
+  # Shown as the publisher of the notice.
+  organization: ""
+  # Where a reader should write with open source compliance questions.
+  contact_email: ""
+  # Named in the copyright footer. Defaults to the organization.
+  copyright_holder: ""
+  # Four-digit year for that footer. Defaults to the SBOM creation year.
+  copyright_year:
+  # Where the corresponding source code can be obtained.
+  source_download_url: ""
+
+# Output language. en is the only one at present.
+default_lang: en
+# Notice theme, matching a directory under onot/rendering/themes.
+theme: default
+# Keep to the bundled license texts instead of fetching missing ones.
+offline: true
+"""
+
+
+@app.command()
+def init(
+    path: Path = typer.Option(
+        Path("onot.yaml"), "-o", "--output", help="Where to write the configuration file."
+    ),
+    force: bool = typer.Option(False, "--force", help="Overwrite the file if it already exists."),
+) -> None:
+    """Write a commented onot.yaml to start from."""
+    if path.exists() and not force:
+        typer.echo(f"error: {path} already exists. Pass --force to overwrite it.", err=True)
+        raise typer.Exit(1)
+    path.write_text(_CONFIG_TEMPLATE, encoding="utf-8")
+    typer.echo(f"wrote {path}")
 
 
 @app.command()

--- a/src/onot/cli/warnings.py
+++ b/src/onot/cli/warnings.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Grouping for the warnings the CLI reports.
+
+A large SBOM can produce hundreds of lines, one per component, which scrolls the useful part
+of the run off the screen. The lines still print, but a count by kind goes last so the shape of
+the problem is visible without reading all of them.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Iterable
+
+# Ordered: the first pattern that matches decides the kind.
+_KINDS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("components without license information", re.compile(r"^no license information for ")),
+    ("licenses without bundled text", re.compile(r"^missing license text for ")),
+    ("unparseable license expressions", re.compile(r"^unparseable expression for ")),
+)
+_OTHER = "other"
+
+
+def classify(warning: str) -> str:
+    for label, pattern in _KINDS:
+        if pattern.match(warning):
+            return label
+    return _OTHER
+
+
+def summarize(warnings: Iterable[str]) -> str:
+    """One line naming the total and the breakdown, or "" when there is nothing to report."""
+    counts = Counter(classify(warning) for warning in warnings)
+    total = sum(counts.values())
+    if total == 0:
+        return ""
+    order = [label for label, _ in _KINDS] + [_OTHER]
+    parts = [f"{counts[label]} {label}" for label in order if counts[label]]
+    noun = "warning" if total == 1 else "warnings"
+    return f"{total} {noun} ({', '.join(parts)})"

--- a/src/onot/rendering/i18n/en.yaml
+++ b/src/onot/rendering/i18n/en.yaml
@@ -3,6 +3,8 @@ notice.intro: "This product includes open source software components listed belo
 notice.generated: "Generated: {date}"
 section.components: "Components"
 section.licenses: "Licenses"
+toc.title: "Contents"
+back_to_top: "Back to top"
 table.name: "Name"
 table.version: "Version"
 table.license: "License"

--- a/src/onot/rendering/templates/html/notice.html.jinja
+++ b/src/onot/rendering/templates/html/notice.html.jinja
@@ -3,18 +3,40 @@
 <head>
 <meta charset="utf-8">
 <title>{{ t("notice.title", product=ctx.product) }}</title>
+{# The theme stylesheet is package data, not user input, and <style> is a raw-text element:
+   an escaped quote stays literal there rather than being decoded, which invalidated the
+   declaration it appeared in. Autoescaping it broke the font stack in every notice. #}
 <style>
-{{ css }}
+{{ css | safe }}
 </style>
 </head>
-<body>
+<body id="top">
 <h1>{{ t("notice.title", product=ctx.product) }}</h1>
 {% if ctx.generated %}
 <p class="generated">{{ t("notice.generated", date=ctx.generated) }}</p>
 {% endif %}
 <p class="intro">{{ t("notice.intro") }}</p>
 
-<h2>{{ t("section.components") }}</h2>
+{# A real notice runs to hundreds of components and dozens of full licence texts, which is
+   more than anyone can navigate by scrolling. #}
+<nav class="toc" aria-label="{{ t('toc.title') }}">
+<h2>{{ t("toc.title") }}</h2>
+<ul>
+<li><a href="#components">{{ t("section.components") }}</a></li>
+<li><a href="#licenses">{{ t("section.licenses") }}</a>
+{% if doc.licenses %}
+<ul class="toc-licenses">
+{% for lic in doc.licenses %}
+<li><a href="#{{ lic.license_id | anchor }}">{{ lic.name }}</a></li>
+{% endfor %}
+</ul>
+{% endif %}
+</li>
+<li><a href="#offer">{{ t("offer.title") }}</a></li>
+</ul>
+</nav>
+
+<h2 id="components">{{ t("section.components") }}</h2>
 <table>
 <thead><tr><th>{{ t("table.name") }}</th><th>{{ t("table.version") }}</th><th>{{ t("table.license") }}</th><th>{{ t("table.copyright") }}</th></tr></thead>
 <tbody>
@@ -29,18 +51,23 @@
 </tbody>
 </table>
 
-<h2>{{ t("section.licenses") }}</h2>
+<h2 id="licenses">{{ t("section.licenses") }}</h2>
 {% for lic in doc.licenses %}
 <div class="license" id="{{ lic.license_id | anchor }}">
 <h3>{{ lic.name }} ({{ lic.license_id }}){% if lic.is_deprecated %} ({{ t("license.deprecated") }}){% endif %}</h3>
-<p class="used-by">{{ t("license.used_by") }}: {{ lic.used_by | map(attribute="display") | join(", ") }}</p>
+{# Each user links back to its table row, so a reader who arrived from the table can go back
+   to any of the other components under the same licence. #}
+<p class="used-by">{{ t("license.used_by") }}: {% for ref in lic.used_by %}<a href="#pkg-{{ ref.name | anchor }}">{{ ref.display }}</a>{% if not loop.last %}, {% endif %}{% endfor %}</p>
 {% if lic.text %}
 <pre>{{ lic.text }}</pre>
+{% endif %}
+{% if doc.licenses | length > 10 %}
+<p class="back-to-top"><a href="#top">{{ t("back_to_top") }}</a></p>
 {% endif %}
 </div>
 {% endfor %}
 
-<h2>{{ t("offer.title") }}</h2>
+<h2 id="offer">{{ t("offer.title") }}</h2>
 <p>{{ t("offer.body") }}</p>
 {% if ctx.source_url %}
 <p>{{ t("offer.source_url", url=ctx.source_url) }}</p>

--- a/src/onot/rendering/themes/default/notice.css
+++ b/src/onot/rendering/themes/default/notice.css
@@ -1,6 +1,9 @@
 /* Notice theme. The colours are named here and shared with the desktop app's tokens so a
-   notice looks the same in the in-app preview and in the saved file. */
+   notice looks the same in the in-app preview and in the saved file. See docs/DESIGN.md. */
 :root {
+  /* Named once so the paged stylesheet can reuse it: an @page margin box does not inherit
+     from body, and without this the page numbers came out in the default serif. */
+  --notice-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   --notice-fg: #1a1a1a;
   --notice-fg-muted: #555555; /* 7.4:1 on white */
   --notice-fg-subtle: #6b7280; /* 4.8:1 on white, the lightest text used */
@@ -11,7 +14,7 @@
   --notice-fill-code: #f7f7f7;
 }
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-family: var(--notice-font);
   margin: 2rem auto;
   max-width: 60rem;
   padding: 0 1rem;
@@ -26,9 +29,15 @@ a { color: var(--notice-link); }
 table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
 th, td { border: 1px solid var(--notice-rule); padding: .45rem .6rem; text-align: left; font-size: .9rem; vertical-align: top; }
 th { background: var(--notice-fill); }
+.toc { margin: 1.5rem 0; }
+.toc h2 { font-size: 1.05rem; margin: 0 0 .4rem; border: 0; padding: 0; }
+.toc ul { margin: .2rem 0; padding-left: 1.2rem; }
+.toc-licenses { columns: 2; column-gap: 2rem; font-size: .9rem; }
+.toc-licenses li { break-inside: avoid; }
 .license { margin: 1.5rem 0; }
+.back-to-top { font-size: .8rem; margin: .4rem 0 0; }
 .license .used-by { color: var(--notice-fg-muted); font-size: .85rem; margin: .2rem 0 .5rem; }
-pre { background: var(--notice-fill-code); padding: .8rem; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; font-size: .8rem; border-radius: 4px; }
+pre { background: var(--notice-fill-code); padding: .8rem; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; font-size: .85rem; border-radius: 4px; }
 footer { margin-top: 2rem; color: var(--notice-fg-subtle); font-size: .85rem; }
 
 /* Paged output. Both routes to a PDF read these rules: WeasyPrint on the CLI side, and
@@ -48,6 +57,7 @@ footer { margin-top: 2rem; color: var(--notice-fg-subtle); font-size: .85rem; }
   h1, h2, h3 { page-break-after: avoid; break-after: avoid; }
   .license .used-by { page-break-after: avoid; break-after: avoid; }
   pre { orphans: 3; widows: 3; background: transparent; padding: 0; }
+  .back-to-top { display: none; }
   /* Repeat the column headers when the component table spans pages. */
   thead { display: table-header-group; }
   tr { page-break-inside: avoid; break-inside: avoid; }

--- a/src/onot/rendering/themes/default/pdf.css
+++ b/src/onot/rendering/themes/default/pdf.css
@@ -3,7 +3,12 @@
 @page {
   size: A4;
   margin: 2cm;
-  @bottom-center { content: counter(page) " / " counter(pages); color: #6b7280; font-size: 9pt; }
+  @bottom-center {
+    content: counter(page) " / " counter(pages);
+    color: #6b7280;
+    font-size: 9pt;
+    font-family: var(--notice-font, sans-serif);
+  }
 }
 body { font-size: 10pt; }
 pre { font-size: 8pt; }

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+"""onot init: the configuration template, which used to exist only as fields in config.py."""
+
+from __future__ import annotations
+
+import yaml
+from typer.testing import CliRunner
+
+from onot.cli.main import app
+from onot.core.config import CompanyConfig, Settings, load_settings
+
+runner = CliRunner()
+
+
+def test_init_writes_a_file_the_loader_accepts(tmp_path):
+    target = tmp_path / "onot.yaml"
+    result = runner.invoke(app, ["init", "--output", str(target)])
+    assert result.exit_code == 0, result.output
+    assert target.exists()
+
+    # The template has to load, or it teaches the wrong shape.
+    settings = load_settings(target)
+    assert isinstance(settings, Settings)
+    assert settings.default_lang == "en"
+
+
+def test_the_template_covers_every_company_field(tmp_path):
+    """A reader should not have to open config.py to learn the field names."""
+    target = tmp_path / "onot.yaml"
+    runner.invoke(app, ["init", "--output", str(target)])
+    data = yaml.safe_load(target.read_text(encoding="utf-8"))
+    assert set(data["company"]) == set(CompanyConfig.model_fields)
+
+
+def test_init_refuses_to_overwrite_without_force(tmp_path):
+    target = tmp_path / "onot.yaml"
+    target.write_text("company:\n  organization: Mine\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["init", "--output", str(target)])
+    assert result.exit_code == 1
+    assert "already exists" in result.output
+    assert "Mine" in target.read_text(encoding="utf-8")
+
+    forced = runner.invoke(app, ["init", "--output", str(target), "--force"])
+    assert forced.exit_code == 0
+    assert "Mine" not in target.read_text(encoding="utf-8")

--- a/tests/cli/test_cli_reporting.py
+++ b/tests/cli/test_cli_reporting.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+"""How the CLI reports a run: the warning summary, --quiet and --json."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from onot.cli.main import app
+from onot.cli.warnings import summarize
+
+ROOT = Path(__file__).resolve().parents[2]
+SPDX_JSON = ROOT / "tests" / "fixtures" / "sbom" / "example.spdx.json"
+
+runner = CliRunner()
+
+
+def _sbom_with_warnings(tmp_path: Path) -> Path:
+    """Two packages with no license information, which the resolver warns about."""
+    packages = [
+        {
+            "SPDXID": f"SPDXRef-p{index}",
+            "name": f"p{index}",
+            "downloadLocation": "NOASSERTION",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "filesAnalyzed": False,
+        }
+        for index in range(2)
+    ]
+    sbom = tmp_path / "w.spdx.json"
+    sbom.write_text(
+        json.dumps(
+            {
+                "spdxVersion": "SPDX-2.3",
+                "dataLicense": "CC0-1.0",
+                "SPDXID": "SPDXRef-DOCUMENT",
+                "name": "w",
+                "documentNamespace": "https://example.com/w",
+                "creationInfo": {"created": "2024-01-01T00:00:00Z", "creators": ["Tool: t"]},
+                "packages": packages,
+                "relationships": [
+                    {
+                        "spdxElementId": "SPDXRef-DOCUMENT",
+                        "relatedSpdxElement": package["SPDXID"],
+                        "relationshipType": "DESCRIBES",
+                    }
+                    for package in packages
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return sbom
+
+
+def test_summarize_groups_by_kind():
+    assert summarize([]) == ""
+    assert summarize(["no license information for a 1"]) == (
+        "1 warning (1 components without license information)"
+    )
+    assert summarize(
+        [
+            "no license information for a 1",
+            "no license information for b 2",
+            "missing license text for MIT",
+            "something else entirely",
+        ]
+    ) == (
+        "4 warnings (2 components without license information, "
+        "1 licenses without bundled text, 1 other)"
+    )
+
+
+def test_warnings_end_with_a_count_by_kind(tmp_path):
+    sbom = _sbom_with_warnings(tmp_path)
+    result = runner.invoke(app, ["generate", "-i", str(sbom), "--output-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "no license information for p0" in result.output
+    assert "2 warnings (2 components without license information)" in result.output
+
+
+def test_quiet_drops_the_warnings_but_keeps_the_result(tmp_path):
+    sbom = _sbom_with_warnings(tmp_path)
+    result = runner.invoke(
+        app, ["generate", "-i", str(sbom), "--output-dir", str(tmp_path), "--quiet"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "warning: " not in result.output
+    assert "no license information" not in result.output
+    assert "wrote " in result.output
+
+
+def test_json_reports_the_files_and_the_warnings(tmp_path):
+    sbom = _sbom_with_warnings(tmp_path)
+    result = runner.invoke(
+        app, ["generate", "-i", str(sbom), "-f", "html", "--output-dir", str(tmp_path), "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["product"] == "w"
+    assert [entry["format"] for entry in payload["written"]] == ["html"]
+    assert Path(payload["written"][0]["path"]).exists()
+    assert len(payload["warnings"]) == 2
+    # Machine output has to parse on its own, so nothing else may share stdout.
+    assert "wrote " not in result.stdout
+
+
+def test_json_and_stdout_together_are_refused():
+    result = runner.invoke(
+        app, ["generate", "-i", str(SPDX_JSON), "-f", "text", "--stdout", "--json"]
+    )
+    assert result.exit_code == 1
+    assert "both write to stdout" in result.output

--- a/tests/golden/slice_notice.html
+++ b/tests/golden/slice_notice.html
@@ -4,20 +4,23 @@
 <meta charset="utf-8">
 <title>OSS Notice for SPDX-Tools-v2.0</title>
 <style>
-/* Notice theme. The colours are named here and shared with the desktop app&#39;s tokens so a
-   notice looks the same in the in-app preview and in the saved file. */
+/* Notice theme. The colours are named here and shared with the desktop app's tokens so a
+   notice looks the same in the in-app preview and in the saved file. See docs/DESIGN.md. */
 :root {
+  /* Named once so the paged stylesheet can reuse it: an @page margin box does not inherit
+     from body, and without this the page numbers came out in the default serif. */
+  --notice-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   --notice-fg: #1a1a1a;
   --notice-fg-muted: #555555; /* 7.4:1 on white */
   --notice-fg-subtle: #6b7280; /* 4.8:1 on white, the lightest text used */
-  --notice-link: #4338ca; /* 7.9:1 on white, the app&#39;s accent */
+  --notice-link: #4338ca; /* 7.9:1 on white, the app's accent */
   --notice-rule: #dddddd;
   --notice-rule-soft: #eeeeee;
   --notice-fill: #f5f5f5;
   --notice-fill-code: #f7f7f7;
 }
 body {
-  font-family: -apple-system, BlinkMacSystemFont, &#34;Segoe UI&#34;, Helvetica, Arial, sans-serif;
+  font-family: var(--notice-font);
   margin: 2rem auto;
   max-width: 60rem;
   padding: 0 1rem;
@@ -32,13 +35,19 @@ a { color: var(--notice-link); }
 table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
 th, td { border: 1px solid var(--notice-rule); padding: .45rem .6rem; text-align: left; font-size: .9rem; vertical-align: top; }
 th { background: var(--notice-fill); }
+.toc { margin: 1.5rem 0; }
+.toc h2 { font-size: 1.05rem; margin: 0 0 .4rem; border: 0; padding: 0; }
+.toc ul { margin: .2rem 0; padding-left: 1.2rem; }
+.toc-licenses { columns: 2; column-gap: 2rem; font-size: .9rem; }
+.toc-licenses li { break-inside: avoid; }
 .license { margin: 1.5rem 0; }
+.back-to-top { font-size: .8rem; margin: .4rem 0 0; }
 .license .used-by { color: var(--notice-fg-muted); font-size: .85rem; margin: .2rem 0 .5rem; }
-pre { background: var(--notice-fill-code); padding: .8rem; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; font-size: .8rem; border-radius: 4px; }
+pre { background: var(--notice-fill-code); padding: .8rem; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; font-size: .85rem; border-radius: 4px; }
 footer { margin-top: 2rem; color: var(--notice-fg-subtle); font-size: .85rem; }
 
 /* Paged output. Both routes to a PDF read these rules: WeasyPrint on the CLI side, and
-   Chromium&#39;s printToPDF in the desktop app, which is why they live with the notice rather than
+   Chromium's printToPDF in the desktop app, which is why they live with the notice rather than
    in the WeasyPrint-only stylesheet. */
 @media print {
   body {
@@ -54,6 +63,7 @@ footer { margin-top: 2rem; color: var(--notice-fg-subtle); font-size: .85rem; }
   h1, h2, h3 { page-break-after: avoid; break-after: avoid; }
   .license .used-by { page-break-after: avoid; break-after: avoid; }
   pre { orphans: 3; widows: 3; background: transparent; padding: 0; }
+  .back-to-top { display: none; }
   /* Repeat the column headers when the component table spans pages. */
   thead { display: table-header-group; }
   tr { page-break-inside: avoid; break-inside: avoid; }
@@ -62,11 +72,33 @@ footer { margin-top: 2rem; color: var(--notice-fg-subtle); font-size: .85rem; }
 
 </style>
 </head>
-<body>
+<body id="top">
 <h1>OSS Notice for SPDX-Tools-v2.0</h1>
 <p class="intro">This product includes open source software components listed below. The full license texts are reproduced in the Licenses section.</p>
 
-<h2>Components</h2>
+<nav class="toc" aria-label="Contents">
+<h2>Contents</h2>
+<ul>
+<li><a href="#components">Components</a></li>
+<li><a href="#licenses">Licenses</a>
+<ul class="toc-licenses">
+<li><a href="#Autoconf-exception-2.0">Autoconf exception 2.0</a></li>
+<li><a href="#BSD-3-Clause">BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</a></li>
+<li><a href="#Bison-exception-2.2">Bison exception 2.2</a></li>
+<li><a href="#GPL-2.0-only">GNU General Public License v2.0 only</a></li>
+<li><a href="#GPL-2.0-or-later">GNU General Public License v2.0 or later</a></li>
+<li><a href="#LGPL-2.0-only">GNU Library General Public License v2 only</a></li>
+<li><a href="#LGPL-2.0-or-later">GNU Library General Public License v2 or later</a></li>
+<li><a href="#LGPL-2.1-only">GNU Lesser General Public License v2.1 only</a></li>
+<li><a href="#LicenseRef-3">CyberNeko License</a></li>
+<li><a href="#MIT">MIT License</a></li>
+</ul>
+</li>
+<li><a href="#offer">Offer of Source Code</a></li>
+</ul>
+</nav>
+
+<h2 id="components">Components</h2>
 <table>
 <thead><tr><th>Name</th><th>Version</th><th>License</th><th>Copyright</th></tr></thead>
 <tbody>
@@ -97,10 +129,10 @@ footer { margin-top: 2rem; color: var(--notice-fg-subtle); font-size: .85rem; }
 </tbody>
 </table>
 
-<h2>Licenses</h2>
+<h2 id="licenses">Licenses</h2>
 <div class="license" id="Autoconf-exception-2.0">
 <h3>Autoconf exception 2.0 (Autoconf-exception-2.0)</h3>
-<p class="used-by">Used by: Saxon 8.8</p>
+<p class="used-by">Used by: <a href="#pkg-Saxon">Saxon 8.8</a></p>
 <pre>As a special exception, the Free Software Foundation gives unlimited permission to copy, distribute and modify the configure scripts that are the output of Autoconf. You need not follow the terms of the GNU General Public License when using or distributing such scripts, even though portions of the text of Autoconf appear in them. The GNU General Public License (GPL) does govern all other use of the material that constitutes the Autoconf program.
 
 Certain portions of the Autoconf source text are designed to be copied (in certain cases, depending on the input) into the output of Autoconf. We call these the &#34;data&#34; portions. The rest of the Autoconf source text consists of comments plus executable code that decides which of the data portions to output in any given case. We call these comments and executable code the &#34;non-data&#34; portions. Autoconf never copies any of the non-data portions into its output.
@@ -110,7 +142,7 @@ This special exception to the GPL applies to versions of Autoconf released by th
 </div>
 <div class="license" id="BSD-3-Clause">
 <h3>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License (BSD-3-Clause)</h3>
-<p class="used-by">Used by: Jena 3.12.0</p>
+<p class="used-by">Used by: <a href="#pkg-Jena">Jena 3.12.0</a></p>
 <pre>Copyright (c) &lt;year&gt; &lt;owner&gt;. 
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -126,7 +158,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &#34;AS IS&#
 </div>
 <div class="license" id="Bison-exception-2.2">
 <h3>Bison exception 2.2 (Bison-exception-2.2)</h3>
-<p class="used-by">Used by: glibc 2.11.1</p>
+<p class="used-by">Used by: <a href="#pkg-glibc">glibc 2.11.1</a></p>
 <pre>Bison Exception
 
 As a special exception, you may create a larger work that contains part or all of the Bison parser skeleton and distribute that work under terms of your choice, so long as that work isn&#39;t itself a parser generator using the skeleton or a modified version thereof as a parser skeleton. Alternatively, if you modify or redistribute the parser skeleton itself, you may (at your option) remove this special exception, which will cause the skeleton and the resulting Bison output files to be licensed under the GNU General Public License without this special exception.
@@ -136,7 +168,7 @@ This special exception was added by the Free Software Foundation in version 2.2 
 </div>
 <div class="license" id="GPL-2.0-only">
 <h3>GNU General Public License v2.0 only (GPL-2.0-only)</h3>
-<p class="used-by">Used by: Saxon 8.8</p>
+<p class="used-by">Used by: <a href="#pkg-Saxon">Saxon 8.8</a></p>
 <pre>GNU GENERAL PUBLIC LICENSE
 Version 2, June 1991
 
@@ -258,7 +290,7 @@ signature of Ty Coon, 1 April 1989 Ty Coon, President of Vice
 </div>
 <div class="license" id="GPL-2.0-or-later">
 <h3>GNU General Public License v2.0 or later (GPL-2.0-or-later)</h3>
-<p class="used-by">Used by: glibc 2.11.1</p>
+<p class="used-by">Used by: <a href="#pkg-glibc">glibc 2.11.1</a></p>
 <pre>GNU GENERAL PUBLIC LICENSE
 Version 2, June 1991
 
@@ -380,7 +412,7 @@ signature of Ty Coon, 1 April 1989 Ty Coon, President of Vice
 </div>
 <div class="license" id="LGPL-2.0-only">
 <h3>GNU Library General Public License v2 only (LGPL-2.0-only)</h3>
-<p class="used-by">Used by: glibc 2.11.1</p>
+<p class="used-by">Used by: <a href="#pkg-glibc">glibc 2.11.1</a></p>
 <pre>GNU LIBRARY GENERAL PUBLIC LICENSE
 
 Version 2, June 1991
@@ -560,7 +592,7 @@ That&#39;s all there is to it!
 </div>
 <div class="license" id="LGPL-2.0-or-later">
 <h3>GNU Library General Public License v2 or later (LGPL-2.0-or-later)</h3>
-<p class="used-by">Used by: Apache Commons Lang 1.1</p>
+<p class="used-by">Used by: <a href="#pkg-Apache_Commons_Lang">Apache Commons Lang 1.1</a></p>
 <pre>GNU LIBRARY GENERAL PUBLIC LICENSE
 
 Version 2, June 1991
@@ -740,7 +772,7 @@ That&#39;s all there is to it!
 </div>
 <div class="license" id="LGPL-2.1-only">
 <h3>GNU Lesser General Public License v2.1 only (LGPL-2.1-only)</h3>
-<p class="used-by">Used by: Jena 3.12.0</p>
+<p class="used-by">Used by: <a href="#pkg-Jena">Jena 3.12.0</a></p>
 <pre>GNU LESSER GENERAL PUBLIC LICENSE
 
 Version 2.1, February 1999
@@ -921,7 +953,7 @@ That&#39;s all there is to it!
 </div>
 <div class="license" id="LicenseRef-3">
 <h3>CyberNeko License (LicenseRef-3)</h3>
-<p class="used-by">Used by: Apache Commons Lang 1.1, glibc 2.11.1</p>
+<p class="used-by">Used by: <a href="#pkg-Apache_Commons_Lang">Apache Commons Lang 1.1</a>, <a href="#pkg-glibc">glibc 2.11.1</a></p>
 <pre>The CyberNeko Software License, Version 1.0
 
  
@@ -968,7 +1000,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</pre>
 </div>
 <div class="license" id="MIT">
 <h3>MIT License (MIT)</h3>
-<p class="used-by">Used by: Jena 3.12.0, Saxon 8.8</p>
+<p class="used-by">Used by: <a href="#pkg-Jena">Jena 3.12.0</a>, <a href="#pkg-Saxon">Saxon 8.8</a></p>
 <pre>MIT License
 
 Copyright (c) &lt;year&gt; &lt;copyright holders&gt;
@@ -990,7 +1022,7 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre>
 </div>
 
-<h2>Offer of Source Code</h2>
+<h2 id="offer">Offer of Source Code</h2>
 <p>This product contains open source software. Where required by the applicable license, you may obtain the corresponding source code.</p>
 <footer>
 <p class="generator">Generated by onot 0.0.0-test.</p>

--- a/tests/rendering/test_escape.py
+++ b/tests/rendering/test_escape.py
@@ -57,3 +57,24 @@ def test_markdown_escapes_company_field_link():
     md = render(doc, "markdown", settings=settings)
     line = next(line for line in md.splitlines() if "javascript" in line)
     assert "\\[x\\]" in line
+
+
+def test_theme_css_is_not_html_escaped():
+    """<style> is a raw-text element, so an escaped quote there stays literal.
+
+    Autoescaping the stylesheet turned every quoted font name into &#34;...&#34;, which made
+    the whole font-family declaration invalid and left notices in the default serif.
+    """
+    html = render(NoticeDocument(name="prod"), "html")
+    style = html[html.index("<style>") : html.index("</style>")]
+    assert '"Segoe UI"' in style
+    assert "&#34;" not in style
+    assert "&amp;" not in style
+
+
+def test_document_content_is_still_escaped():
+    """The stylesheet is trusted package data; nothing else in the notice is."""
+    doc = NoticeDocument(name='prod<script>alert("x")</script>')
+    html = render(doc, "html")
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html

--- a/tests/rendering/test_html_navigation.py
+++ b/tests/rendering/test_html_navigation.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Kakao Corp. and SK telecom Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Navigation inside an HTML notice: contents, licence anchors, links back to the components."""
+
+from __future__ import annotations
+
+import re
+
+from onot.domain.models import License, LicenseExpression, NoticeDocument, Package, PackageRef
+from onot.rendering import render
+
+
+def _doc(license_count: int = 2) -> NoticeDocument:
+    ids = [f"LIC-{index}" for index in range(license_count)]
+    packages = tuple(
+        Package(name=f"pkg{index}", version="1", license_concluded=LicenseExpression(raw=lic))
+        for index, lic in enumerate(ids)
+    )
+    licenses = tuple(
+        License(
+            license_id=lic,
+            name=f"License {index}",
+            text="body",
+            used_by=(PackageRef(name=f"pkg{index}", version="1"),),
+        )
+        for index, lic in enumerate(ids)
+    )
+    return NoticeDocument(name="prod", packages=packages, licenses=licenses)
+
+
+def _hrefs(html: str) -> set[str]:
+    return {match[1:] for match in re.findall(r'href="(#[^"]+)"', html)}
+
+
+def _ids(html: str) -> set[str]:
+    return set(re.findall(r'id="([^"]+)"', html))
+
+
+def test_every_internal_link_has_a_target():
+    """A dangling anchor is a dead end for the reader and invisible in review."""
+    html = render(_doc(3), "html")
+    assert _hrefs(html) <= _ids(html)
+
+
+def test_contents_lists_the_sections_and_every_licence():
+    html = render(_doc(3), "html")
+    contents = html[html.index("<nav") : html.index("</nav>")]
+    for target in ("#components", "#licenses", "#offer"):
+        assert f'href="{target}"' in contents
+    for index in range(3):
+        assert f'href="#LIC-{index}"' in contents
+
+
+def test_a_licence_links_back_to_the_components_that_use_it():
+    html = render(_doc(2), "html")
+    assert 'href="#pkg-pkg0"' in html
+    assert 'id="pkg-pkg0"' in html
+
+
+def test_back_to_top_appears_only_when_the_notice_is_long():
+    """Two licences fit on a screen; forty do not."""
+    assert 'href="#top"' not in render(_doc(3), "html")
+    assert 'href="#top"' in render(_doc(11), "html")
+
+
+def test_the_licence_heading_carries_the_identifier():
+    html = render(_doc(1), "html")
+    assert "License 0 (LIC-0)" in html


### PR DESCRIPTION
Third and last batch of the UI/UX review, on top of #128. Checks are empty here because
Actions are paused on this organisation; CI runs on the fork against the same commit:
haksungjang/onot#7.

## Please look at one thing

The notice preview frame goes from `sandbox=""` to `sandbox="allow-same-origin"`. It still
withholds `allow-scripts`, so nothing in a notice executes: no script, no form, no
navigation of the app around it. The pairing to avoid is `allow-same-origin` together with
`allow-scripts`, where a frame can lift its own sandbox; with scripts withheld there is
nothing to lift it with, and the notice is autoescaped Jinja output under the app's CSP on
top of that. It is granted because a fully opaque origin refuses the document's own anchor
links, which left the new table of contents inert. `electron/e2e/preview-navigation.e2e.mjs`
asserts the sandbox value so the pairing cannot appear by accident.

## Two defects, both shipped for a while

The theme stylesheet was HTML-escaped into the `<style>` element, turning every quoted font
name into `&#34;`. `<style>` is a raw-text element, so the entity is never decoded: the
whole `font-family` declaration was invalid and every notice, HTML and PDF alike, fell back
to the default serif. The PDFs in this repository carry PT-Serif. It goes through with
`| safe` now, the stylesheet being package data rather than user input, and a test covers
both halves: the stylesheet keeps its quotes, document content is still escaped. This also
retires the question of bundling a font, which the plan had raised.

The preview showed the notice through `srcdoc`, and an `about:srcdoc` document takes its
base URL from the parent. A link to `#licenses` therefore resolved against the app's own
URL, so clicking one navigated the frame to the app and left the preview blank. The frame
loads a blob URL now, which has a URL of its own.

## The rest

HTML notices open with a table of contents, and a licence links back to every component
that uses it, so a reader who arrived from the components table can move between the two.
Past ten licences each block ends with a way back to the top. None of it prints. A test
asserts no internal link is a dead end.

The CLI ends a run with a count of warnings by kind, which is what tells you whether the
hundreds of lines over a large SBOM matter. `--quiet` drops them and `--json` puts the
written files and the warnings on stdout. `onot init` writes a commented `onot.yaml`; the
schema existed only as fields in `config.py`.

Help offers Check for Updates, which opens the releases page in a browser rather than
querying an API: onot's claim is that it works offline and reaches nothing on its own,
which is worth more than saving a comparison of two version numbers. Proper update handling
belongs with electron-updater once the signing certificate is decided.

`docs/DESIGN.md` records the tokens, the contrast bar CI enforces, the wording conventions,
and the four traps this work paid for. CONTRIBUTING points at it.

## Verification

Python 212 tests at 97.39% coverage, frontend 62, Electron 17 unit and 14 E2E.
