### PR TITLE
ci(release): build the repository being released, and check it carries the version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,11 @@ on:
         required: false
         type: string
         default: ""
+      source_ref:
+        description: "Commit or branch in the target repository to build (default: its default branch)"
+        required: false
+        type: string
+        default: ""
     secrets:
       PUBLISH_TOKEN:
         description: "Token with contents:write on the target repository (default: the run GITHUB_TOKEN)"
@@ -86,7 +91,31 @@ jobs:
         os: [windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      # A caller's checkout would bring that repository's branch, which is a copy of this
+      # one only by coincidence. v1.1.3 shipped from a caller branch that predated the
+      # fix it was named after. Always take the source from the repository being
+      # released, so the caller supplies only the workflow, never the code.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ inputs.owner && format('{0}/{1}', inputs.owner, inputs.repo) || github.repository }}
+          ref: ${{ inputs.owner && inputs.source_ref || github.ref }}
+      - name: Check the source carries the version being released
+        # The tag names the version, but nothing forces the checked-out tree to agree.
+        # v1.1.3 was built from a tree still saying 1.1.2 and shipped anyway, carrying
+        # none of the fix the tag promised. Compare the two before anything is built.
+        shell: bash
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          declared=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/^version = "(.*)"$/\1/')
+          echo "tag says $VERSION, pyproject.toml says $declared"
+          # A .devN suffix on the same version is fine: publish-pypi strips it deliberately.
+          case "$declared" in
+            "$VERSION" | "$VERSION".dev*) ;;
+            *)
+              echo "the source tree is not the one this release names; bump the version and merge it first"
+              exit 1
+              ;;
+          esac
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
@@ -169,7 +198,31 @@ jobs:
       name: pypi
       url: https://pypi.org/project/onot/
     steps:
+      # A caller's checkout would bring that repository's branch, which is a copy of this
+      # one only by coincidence. v1.1.3 shipped from a caller branch that predated the
+      # fix it was named after. Always take the source from the repository being
+      # released, so the caller supplies only the workflow, never the code.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ inputs.owner && format('{0}/{1}', inputs.owner, inputs.repo) || github.repository }}
+          ref: ${{ inputs.owner && inputs.source_ref || github.ref }}
+      - name: Check the source carries the version being released
+        # The tag names the version, but nothing forces the checked-out tree to agree.
+        # v1.1.3 was built from a tree still saying 1.1.2 and shipped anyway, carrying
+        # none of the fix the tag promised. Compare the two before anything is built.
+        shell: bash
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          declared=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/^version = "(.*)"$/\1/')
+          echo "tag says $VERSION, pyproject.toml says $declared"
+          # A .devN suffix on the same version is fine: publish-pypi strips it deliberately.
+          case "$declared" in
+            "$VERSION" | "$VERSION".dev*) ;;
+            *)
+              echo "the source tree is not the one this release names; bump the version and merge it first"
+              exit 1
+              ;;
+          esac
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
@@ -206,7 +259,14 @@ jobs:
     permissions:
       contents: write # Upload assets to the release
     steps:
+      # A caller's checkout would bring that repository's branch, which is a copy of this
+      # one only by coincidence. v1.1.3 shipped from a caller branch that predated the
+      # fix it was named after. Always take the source from the repository being
+      # released, so the caller supplies only the workflow, never the code.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ inputs.owner && format('{0}/{1}', inputs.owner, inputs.repo) || github.repository }}
+          ref: ${{ inputs.owner && inputs.source_ref || github.ref }}
       - name: Generate CycloneDX SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:


### PR DESCRIPTION
Reopened from a branch on this repository; the fork PR (#131) could not be merged because it touches `.github/workflows`.

v1.1.3 shipped without the security fix it was named for. The artifacts on PyPI, sdist and wheel both, carry `src/onot/ingest/excel.py` at 131 lines with none of the limits the fix adds; `main` has the same file at 185. GHSA-qcgh-vq3j-cm8w names 1.1.3 as the patched version.

## How

The caller workflow lives on a branch of the fork, because putting it on that fork's `main` would make `main` diverge from this repository. A called workflow inherits the caller's `github` context, so the default `actions/checkout` took the caller's ref:

```
git remote add origin https://github.com/haksungjang/onot
git checkout --progress --force -B ci/publish-dry-run refs/remotes/origin/ci/publish-dry-run
```

That branch predates both the advisory merge and the version bump, so syncing the fork's `main` beforehand changed nothing about what was built. The version matched only because it came from the dispatch input, and `publish-pypi` rewrites `pyproject.toml` from the tag -- a step meant to strip a `.devN` suffix, which here erased the evidence that the tree was 1.1.2.

The rehearsals missed it because the caller branch happened to equal `main` at the time. They verified that a build and an upload work, not which source they act on.

## Fix

Two changes, either sufficient on its own.

`actions/checkout` now names the repository being released and takes its default branch, or an explicit `source_ref`. The caller supplies the workflow, never the code.

Before anything is built, the tag is compared against the version declared in the checked-out `pyproject.toml`; a `.devN` suffix on the same version passes, a different version fails the job. It runs in the desktop leg and again in the PyPI leg, which would otherwise overwrite the mismatch.

A re-release as 1.2.0 follows in a separate PR. PyPI does not accept a second upload of 1.1.3.

Verified on haksungjang/onot#8: `ci` and `security` green.