### PR TITLE
chore(release): 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-09-06
+
+### Security
+
+- The XLSX resource-exhaustion fix described under 1.1.3 reaches users here. The 1.1.3
+  artifacts were built from a source tree that predated it, so this is the first release
+  that actually carries it (GHSA-qcgh-vq3j-cm8w).
+
 ### Added
 
 - The desktop app follows the system theme and offers an explicit Light or Dark choice,
@@ -92,6 +100,11 @@ All notable changes to this project are documented here. The format is based on
   rows scanned, and deduplicates packages during the scan so repeated rows do not
   accumulate. Reported and reproduced against 1.1.0 through 1.1.2 (GHSA-qcgh-vq3j-cm8w).
 
+The published 1.1.3 artifacts do not contain that fix. The release was built from a
+source tree that predated the merge, so the package on PyPI and the installers attached
+to the release are still vulnerable despite carrying the version number. Upgrade to
+1.2.0 instead.
+
 ## [1.1.2] - 2026-07-02
 
 ### Fixed
@@ -171,7 +184,9 @@ generator.
 - Initial public release: PyQt-based desktop generator that produced OSS notices
   from SPDX documents.
 
-[Unreleased]: https://github.com/sktelecom/onot/compare/v1.1.2...HEAD
+[Unreleased]: https://github.com/sktelecom/onot/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/sktelecom/onot/compare/v1.1.3...v1.2.0
+[1.1.3]: https://github.com/sktelecom/onot/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/sktelecom/onot/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/sktelecom/onot/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/sktelecom/onot/compare/1.0.0...v1.1.0

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onot-desktop",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "packageManager": "pnpm@10.34.4",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onot-frontend",
   "private": true,
-  "version": "1.1.3",
+  "version": "1.2.0",
   "packageManager": "pnpm@10.34.4",
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "onot"
-version = "1.1.3"
+version = "1.2.0"
 description = "Generate open source software notices from SBOM/SPDX documents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/onot/__init__.py
+++ b/src/onot/__init__.py
@@ -3,4 +3,4 @@
 
 """onot — open source software notice generator from SBOM/SPDX documents."""
 
-__version__ = "1.1.3"
+__version__ = "1.2.0"


### PR DESCRIPTION
Re-releases the XLSX resource-exhaustion fix, which the 1.1.3 artifacts do not contain (see #132 for how that happened). PyPI does not accept a second upload of 1.1.3, so this goes out as a new version.

Minor rather than patch: the Unreleased section carries the UI/UX work from phases 1 through 3, which adds features.

The 1.1.3 entry now says plainly that its published artifacts lack the fix it describes. Leaving it as written would tell anyone reading the changelog that 1.1.3 is safe, which is how GHSA-qcgh-vq3j-cm8w came to point at a vulnerable version. That advisory has been corrected: the affected range now includes 1.1.3, and `patched_versions` is empty until this release is actually out.

The compare links skipped 1.1.3 entirely; they now run through it.

Verified on haksungjang/onot#9: `ci` and `security` green.