### PR TITLE
ci(release): stop an empty source_ref falling back to the caller's branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,12 @@ on:
         type: string
         default: ""
       source_ref:
-        description: "Commit or branch in the target repository to build (default: its default branch)"
+        description: "Commit or branch in the target repository to build"
         required: false
         type: string
-        default: ""
+        # Not empty: an empty ref falls through the || below to the caller's own ref,
+        # which names a branch that exists on the caller and not on the target.
+        default: "main"
     secrets:
       PUBLISH_TOKEN:
         description: "Token with contents:write on the target repository (default: the run GITHUB_TOKEN)"


### PR DESCRIPTION
The `source_ref` input added in #132 does not work when it is left empty.

GitHub's `&&` / `||` returns the value rather than a boolean, so `inputs.owner && inputs.source_ref || github.ref` yields `github.ref` whenever `source_ref` is empty. The checkout then asked the target repository for the caller's own branch:

```
fatal: couldn't find remote ref refs/heads/ci/publish-dry-run
```

The rehearsal caught it, but only because that branch happens not to exist on this repository. Had a branch of the same name existed here, the release would have built it without complaint -- the same class of fault `source_ref` was added to prevent, just pointing the other way.

Defaulting to `main` keeps the value truthy. A caller that names nothing releases this repository's `main`; a caller that names a ref gets that ref; a tag pushed here still builds the tag, since `inputs.owner` is absent and the expression falls to `github.ref` as intended.

Opened from a branch here rather than the fork: a fork PR touching `.github/workflows` cannot be merged (#131).